### PR TITLE
Add `no-regexp-unicode-property-escapes-2023` rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,6 +10,9 @@ ignorePatterns:
   - "!.vuepress"
   - /docs/.vuepress/dist
 
+globals:
+  fetch: readonly
+
 overrides:
   - files: lib/rules/**/*.js
     rules:

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -16,6 +16,7 @@ There is a config that enables the rules in this category: `plugin:es-x/no-new-i
 | [es-x/no-array-prototype-tospliced](./no-array-prototype-tospliced.md) | disallow the `Array.prototype.toSpliced` method. |  |
 | [es-x/no-array-prototype-with](./no-array-prototype-with.md) | disallow the `Array.prototype.with` method. |  |
 | [es-x/no-hashbang](./no-hashbang.md) | disallow Hashbang comments. |  |
+| [es-x/no-regexp-unicode-property-escapes-2023](./no-regexp-unicode-property-escapes-2023.md) | disallow the new values of RegExp Unicode property escape sequences in ES2023. |  |
 
 ## ES2023 Intl API
 

--- a/docs/rules/no-regexp-unicode-property-escapes-2022.md
+++ b/docs/rules/no-regexp-unicode-property-escapes-2022.md
@@ -11,7 +11,7 @@ since: "v6.0.0"
 
 This rule reports the new values of ES2018 [RegExp Unicode property escape sequences](https://github.com/tc39/proposal-regexp-unicode-property-escapes#readme) which were added in ES2022.
 
-For example, the following patterns are valid in ES2022, but syntax error in ES2020 environments:
+For example, the following patterns are valid in ES2022, but syntax error in ES2021 environments:
 
 - `\p{Script=Cpmn}`
 - `\p{Script=Cypro_Minoan}`

--- a/docs/rules/no-regexp-unicode-property-escapes-2023.md
+++ b/docs/rules/no-regexp-unicode-property-escapes-2023.md
@@ -1,0 +1,38 @@
+---
+title: "es-x/no-regexp-unicode-property-escapes-2023"
+description: "disallow the new values of RegExp Unicode property escape sequences in ES2023"
+---
+
+# es-x/no-regexp-unicode-property-escapes-2023
+> disallow the new values of RegExp Unicode property escape sequences in ES2023
+
+- ❗ <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- ✅ The following configurations enable this rule: `plugin:es-x/no-new-in-esnext`
+
+This rule reports the new values of ES2018 [RegExp Unicode property escape sequences](https://github.com/tc39/proposal-regexp-unicode-property-escapes#readme) which were added in ES2023.
+
+For example, the following patterns are valid in ES2023, but syntax error in ES2022 environments:
+
+- `\p{Script=Kawi}`
+- `\p{Script=Nag_Mundari}`
+- `\p{Script=Nagm}`
+
+## 💡 Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad">
+
+```js
+/*eslint es-x/no-regexp-unicode-property-escapes-2023: error */
+const r1 = /\p{Script=Kawi}/u
+const r2 = /\p{Script=Nag_Mundari}/u
+const r2 = /\p{Script=Nagm}/u
+```
+
+</eslint-playground>
+
+## 📚 References
+
+- [Rule source](https://github.com/eslint-community/eslint-plugin-es-x/blob/master/lib/rules/no-regexp-unicode-property-escapes-2023.js)
+- [Test source](https://github.com/eslint-community/eslint-plugin-es-x/blob/master/tests/lib/rules/no-regexp-unicode-property-escapes-2023.js)

--- a/lib/configs/no-new-in-esnext.js
+++ b/lib/configs/no-new-in-esnext.js
@@ -13,5 +13,6 @@ module.exports = {
         "es-x/no-array-prototype-tospliced": "error",
         "es-x/no-array-prototype-with": "error",
         "es-x/no-hashbang": "error",
+        "es-x/no-regexp-unicode-property-escapes-2023": "error",
     },
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,6 +227,7 @@ module.exports = {
         "no-regexp-unicode-property-escapes-2020": require("./rules/no-regexp-unicode-property-escapes-2020"),
         "no-regexp-unicode-property-escapes-2021": require("./rules/no-regexp-unicode-property-escapes-2021"),
         "no-regexp-unicode-property-escapes-2022": require("./rules/no-regexp-unicode-property-escapes-2022"),
+        "no-regexp-unicode-property-escapes-2023": require("./rules/no-regexp-unicode-property-escapes-2023"),
         "no-regexp-y-flag": require("./rules/no-regexp-y-flag"),
         "no-rest-parameters": require("./rules/no-rest-parameters"),
         "no-rest-spread-properties": require("./rules/no-rest-spread-properties"),

--- a/lib/rules/no-regexp-unicode-property-escapes-2023.js
+++ b/lib/rules/no-regexp-unicode-property-escapes-2023.js
@@ -1,0 +1,66 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const { defineRegExpHandler } = require("../util/define-regexp-handler")
+const {
+    scNameSet,
+    scValueSets,
+    binPropertySets,
+} = require("../util/unicode-properties")
+
+function isNewUnicodePropertyKeyValuePair(key, value) {
+    return scNameSet.has(key) && scValueSets.es2023.has(value)
+}
+
+function isNewBinaryUnicodeProperty(key) {
+    return binPropertySets.es2023.has(key)
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "disallow the new values of RegExp Unicode property escape sequences in ES2023",
+            category: "ES2023",
+            recommended: false,
+            url: "http://eslint-community.github.io/eslint-plugin-es-x/rules/no-regexp-unicode-property-escapes-2023.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES2023 '{{value}}' is forbidden.",
+        },
+        schema: [],
+        type: "problem",
+    },
+    create(context) {
+        return defineRegExpHandler(context, (node, { pattern }) => {
+            let foundValue = ""
+            return {
+                onUnicodePropertyCharacterSet(start, end, _kind, key, value) {
+                    if (foundValue) {
+                        return
+                    }
+                    if (
+                        value
+                            ? isNewUnicodePropertyKeyValuePair(key, value)
+                            : isNewBinaryUnicodeProperty(key)
+                    ) {
+                        foundValue = pattern.slice(start, end)
+                    }
+                },
+                onExit() {
+                    if (foundValue) {
+                        context.report({
+                            node,
+                            messageId: "forbidden",
+                            data: { value: foundValue },
+                        })
+                    }
+                },
+            }
+        })
+    },
+}

--- a/lib/util/unicode-properties.js
+++ b/lib/util/unicode-properties.js
@@ -64,7 +64,7 @@ const scValueSets = new DataSet(
     "Elym Elymaic Hmnp Nand Nandinagari Nyiakeng_Puachue_Hmong Wancho Wcho",
     "Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi",
     "Cpmn Cypro_Minoan Old_Uyghur Ougr Tangsa Tnsa Toto Vith Vithkuqi",
-    "",
+    "Hrkt Katakana_Or_Hiragana Kawi Nag_Mundari Nagm Unknown Zzzz",
 )
 const binPropertySets = new DataSet(
     "AHex ASCII ASCII_Hex_Digit Alpha Alphabetic Any Assigned Bidi_C Bidi_Control Bidi_M Bidi_Mirrored CI CWCF CWCM CWKCF CWL CWT CWU Case_Ignorable Cased Changes_When_Casefolded Changes_When_Casemapped Changes_When_Lowercased Changes_When_NFKC_Casefolded Changes_When_Titlecased Changes_When_Uppercased DI Dash Default_Ignorable_Code_Point Dep Deprecated Dia Diacritic Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Ext Extender Gr_Base Gr_Ext Grapheme_Base Grapheme_Extend Hex Hex_Digit IDC IDS IDSB IDST IDS_Binary_Operator IDS_Trinary_Operator ID_Continue ID_Start Ideo Ideographic Join_C Join_Control LOE Logical_Order_Exception Lower Lowercase Math NChar Noncharacter_Code_Point Pat_Syn Pat_WS Pattern_Syntax Pattern_White_Space QMark Quotation_Mark RI Radical Regional_Indicator SD STerm Sentence_Terminal Soft_Dotted Term Terminal_Punctuation UIdeo Unified_Ideograph Upper Uppercase VS Variation_Selector White_Space XIDC XIDS XID_Continue XID_Start space",

--- a/lib/util/unicode-properties.js
+++ b/lib/util/unicode-properties.js
@@ -2,13 +2,14 @@
 "use strict"
 
 class DataSet {
-    constructor(raw2018, raw2019, raw2020, raw2021, raw2022, raw2023) {
+    constructor(raw2018, raw2019, raw2020, raw2021, raw2022, raw2023, raw2024) {
         this._raw2018 = raw2018
         this._raw2019 = raw2019
         this._raw2020 = raw2020
         this._raw2021 = raw2021
         this._raw2022 = raw2022
         this._raw2023 = raw2023
+        this._raw2024 = raw2024
     }
 
     get es2018() {
@@ -46,12 +47,19 @@ class DataSet {
             this._set2023 || (this._set2023 = new Set(this._raw2023.split(" ")))
         )
     }
+
+    get es2024() {
+        return (
+            this._set2024 || (this._set2024 = new Set(this._raw2024.split(" ")))
+        )
+    }
 }
 
 const gcNameSet = new Set(["General_Category", "gc"])
 const scNameSet = new Set(["Script", "Script_Extensions", "sc", "scx"])
 const gcValueSets = new DataSet(
     "C Cased_Letter Cc Cf Close_Punctuation Cn Co Combining_Mark Connector_Punctuation Control Cs Currency_Symbol Dash_Punctuation Decimal_Number Enclosing_Mark Final_Punctuation Format Initial_Punctuation L LC Letter Letter_Number Line_Separator Ll Lm Lo Lowercase_Letter Lt Lu M Mark Math_Symbol Mc Me Mn Modifier_Letter Modifier_Symbol N Nd Nl No Nonspacing_Mark Number Open_Punctuation Other Other_Letter Other_Number Other_Punctuation Other_Symbol P Paragraph_Separator Pc Pd Pe Pf Pi Po Private_Use Ps Punctuation S Sc Separator Sk Sm So Space_Separator Spacing_Mark Surrogate Symbol Titlecase_Letter Unassigned Uppercase_Letter Z Zl Zp Zs cntrl digit punct",
+    "",
     "",
     "",
     "",
@@ -65,12 +73,14 @@ const scValueSets = new DataSet(
     "Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi",
     "Cpmn Cypro_Minoan Old_Uyghur Ougr Tangsa Tnsa Toto Vith Vithkuqi",
     "Hrkt Katakana_Or_Hiragana Kawi Nag_Mundari Nagm Unknown Zzzz",
+    "",
 )
 const binPropertySets = new DataSet(
     "AHex ASCII ASCII_Hex_Digit Alpha Alphabetic Any Assigned Bidi_C Bidi_Control Bidi_M Bidi_Mirrored CI CWCF CWCM CWKCF CWL CWT CWU Case_Ignorable Cased Changes_When_Casefolded Changes_When_Casemapped Changes_When_Lowercased Changes_When_NFKC_Casefolded Changes_When_Titlecased Changes_When_Uppercased DI Dash Default_Ignorable_Code_Point Dep Deprecated Dia Diacritic Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Ext Extender Gr_Base Gr_Ext Grapheme_Base Grapheme_Extend Hex Hex_Digit IDC IDS IDSB IDST IDS_Binary_Operator IDS_Trinary_Operator ID_Continue ID_Start Ideo Ideographic Join_C Join_Control LOE Logical_Order_Exception Lower Lowercase Math NChar Noncharacter_Code_Point Pat_Syn Pat_WS Pattern_Syntax Pattern_White_Space QMark Quotation_Mark RI Radical Regional_Indicator SD STerm Sentence_Terminal Soft_Dotted Term Terminal_Punctuation UIdeo Unified_Ideograph Upper Uppercase VS Variation_Selector White_Space XIDC XIDS XID_Continue XID_Start space",
     "Extended_Pictographic",
     "",
     "EBase EComp EMod EPres ExtPict",
+    "",
     "",
     "",
 )

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.1.2",
-    "@eslint-community/regexpp": "^4.2.0"
+    "@eslint-community/regexpp": "^4.5.0"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^5.14.0",

--- a/scripts/fetch-lines.js
+++ b/scripts/fetch-lines.js
@@ -1,0 +1,68 @@
+"use strict"
+
+const https = require("https")
+
+module.exports = { fetchLines }
+
+function fetchLines(url) {
+    const linesBuffer = []
+
+    let resolve = undefined
+    let reject = undefined
+
+    function pushNext() {
+        linesBuffer.push(
+            new Promise((res, rej) => {
+                resolve = res
+                reject = rej
+            }),
+        )
+    }
+
+    function resolveLine(line) {
+        resolve({ value: line })
+        pushNext()
+    }
+
+    pushNext()
+
+    const itr = {
+        [Symbol.asyncIterator]() {
+            return {
+                next() {
+                    return linesBuffer.shift()
+                },
+            }
+        },
+    }
+    https
+        .get(url, (res) => {
+            let buffer = ""
+            res.setEncoding("utf8")
+            res.on("data", (chunk) => {
+                const lines = (buffer + String(chunk)).split("\n")
+                if (lines.length === 1) {
+                    buffer = lines[0]
+                } else {
+                    buffer = lines.pop()
+                    for (const line of lines) {
+                        resolveLine(line)
+                    }
+                }
+            })
+            res.on("end", () => {
+                if (buffer) {
+                    resolveLine(buffer)
+                }
+                resolve({ done: true, value: undefined })
+            })
+            res.on("error", (e) => {
+                reject(e)
+            })
+        })
+        .on("error", (e) => {
+            reject(e)
+        })
+
+    return itr
+}

--- a/scripts/fetch-lines.js
+++ b/scripts/fetch-lines.js
@@ -1,68 +1,29 @@
 "use strict"
 
-const https = require("https")
-
 module.exports = { fetchLines }
 
-function fetchLines(url) {
-    const linesBuffer = []
-
-    let resolve = undefined
-    let reject = undefined
-
-    function pushNext() {
-        linesBuffer.push(
-            new Promise((res, rej) => {
-                resolve = res
-                reject = rej
-            }),
-        )
-    }
-
-    function resolveLine(line) {
-        resolve({ value: line })
-        pushNext()
-    }
-
-    pushNext()
-
-    const itr = {
-        [Symbol.asyncIterator]() {
-            return {
-                next() {
-                    return linesBuffer.shift()
-                },
+async function* fetchLines(url) {
+    const response = await fetch(url)
+    const reader = response.body.getReader()
+    let buffer = ""
+    const decoder = new TextDecoder()
+    while (true) {
+        const { done, value: chunk } = await reader.read()
+        if (done) {
+            if (chunk) {
+                buffer += decoder.decode(chunk)
             }
-        },
+            yield buffer
+            break
+        }
+        const lines = (buffer + decoder.decode(chunk)).split("\n")
+        if (lines.length === 1) {
+            buffer = lines[0]
+        } else {
+            buffer = lines.pop()
+            for (const line of lines) {
+                yield line
+            }
+        }
     }
-    https
-        .get(url, (res) => {
-            let buffer = ""
-            res.setEncoding("utf8")
-            res.on("data", (chunk) => {
-                const lines = (buffer + String(chunk)).split("\n")
-                if (lines.length === 1) {
-                    buffer = lines[0]
-                } else {
-                    buffer = lines.pop()
-                    for (const line of lines) {
-                        resolveLine(line)
-                    }
-                }
-            })
-            res.on("end", () => {
-                if (buffer) {
-                    resolveLine(buffer)
-                }
-                resolve({ done: true, value: undefined })
-            })
-            res.on("error", (e) => {
-                reject(e)
-            })
-        })
-        .on("error", (e) => {
-            reject(e)
-        })
-
-    return itr
 }

--- a/scripts/fetch-lines.js
+++ b/scripts/fetch-lines.js
@@ -4,18 +4,5 @@ module.exports = { fetchLines }
 
 async function* fetchLines(url) {
     const response = await fetch(url)
-    let buffer = ""
-    const decoder = new TextDecoder()
-    for await (const chunk of response.body) {
-        const lines = (buffer + decoder.decode(chunk)).split("\n")
-        if (lines.length === 1) {
-            buffer = lines[0]
-        } else {
-            buffer = lines.pop()
-            for (const line of lines) {
-                yield line
-            }
-        }
-    }
-    yield buffer
+    yield* (await response.text()).split("\n")
 }

--- a/scripts/fetch-lines.js
+++ b/scripts/fetch-lines.js
@@ -4,18 +4,9 @@ module.exports = { fetchLines }
 
 async function* fetchLines(url) {
     const response = await fetch(url)
-    const reader = response.body.getReader()
     let buffer = ""
     const decoder = new TextDecoder()
-    while (true) {
-        const { done, value: chunk } = await reader.read()
-        if (done) {
-            if (chunk) {
-                buffer += decoder.decode(chunk)
-            }
-            yield buffer
-            break
-        }
+    for await (const chunk of response.body) {
         const lines = (buffer + decoder.decode(chunk)).split("\n")
         if (lines.length === 1) {
             buffer = lines[0]
@@ -26,4 +17,5 @@ async function* fetchLines(url) {
             }
         }
     }
+    yield buffer
 }

--- a/scripts/get-latest-unicode-general-category-values.js
+++ b/scripts/get-latest-unicode-general-category-values.js
@@ -1,0 +1,29 @@
+"use strict"
+
+const { fetchLines } = require("./fetch-lines")
+
+const DB_URL =
+    "https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"
+const logger = console
+
+module.exports = { getLatestUnicodeGeneralCategoryValues }
+
+async function* getLatestUnicodeGeneralCategoryValues() {
+    logger.log("Fetching data... (%s)", DB_URL)
+    for await (const line of fetchLines(DB_URL)) {
+        if (!line || line.startsWith("#")) {
+            continue
+        }
+        const [propertyAlias, alias, canonical, ...remaining] = line
+            .split("#")[0] // strip comments
+            .split(";") // split by semicolon
+            .map((x) => x.trim()) // trim
+        if (propertyAlias !== "gc") {
+            continue
+        }
+
+        yield alias
+        yield canonical
+        yield* remaining
+    }
+}

--- a/scripts/get-latest-unicode-general-category-values.js
+++ b/scripts/get-latest-unicode-general-category-values.js
@@ -1,29 +1,17 @@
 "use strict"
 
-const { fetchLines } = require("./fetch-lines")
-
-const DB_URL =
-    "https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"
-const logger = console
+const {
+    getLatestUnicodePropertyValues,
+} = require("./get-latest-unicode-property-values")
 
 module.exports = { getLatestUnicodeGeneralCategoryValues }
 
 async function* getLatestUnicodeGeneralCategoryValues() {
-    logger.log("Fetching data... (%s)", DB_URL)
-    for await (const line of fetchLines(DB_URL)) {
-        if (!line || line.startsWith("#")) {
-            continue
-        }
-        const [propertyAlias, alias, canonical, ...remaining] = line
-            .split("#")[0] // strip comments
-            .split(";") // split by semicolon
-            .map((x) => x.trim()) // trim
-        if (propertyAlias !== "gc") {
+    for await (const value of getLatestUnicodePropertyValues()) {
+        if (value.propertyAlias !== "gc") {
             continue
         }
 
-        yield alias
-        yield canonical
-        yield* remaining
+        yield* value.aliases
     }
 }

--- a/scripts/get-latest-unicode-property-values.js
+++ b/scripts/get-latest-unicode-property-values.js
@@ -1,0 +1,39 @@
+"use strict"
+
+const { fetchLines } = require("./fetch-lines")
+const DB_URL =
+    "https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"
+const logger = console
+
+let cache = undefined
+module.exports = { getLatestUnicodePropertyValues }
+
+async function* getLatestUnicodePropertyValues() {
+    logger.log("Fetching data... (%s)", DB_URL)
+    const iterable = cache
+        ? cache
+        : (async function* () {
+              const newCache = []
+              for await (const line of fetchLines(DB_URL)) {
+                  if (!line || line.startsWith("#")) {
+                      continue
+                  }
+                  const [propertyAlias, alias, canonical, ...remaining] = line
+                      .split("#")[0] // strip comments
+                      .split(";") // split by semicolon
+                      .map((x) => x.trim()) // trim
+
+                  const value = {
+                      propertyAlias,
+                      aliases: [canonical, alias, ...remaining],
+                      canonical,
+                  }
+                  newCache.push(value)
+                  yield value
+              }
+              cache = newCache
+          })()
+    for await (const value of iterable) {
+        yield value
+    }
+}

--- a/scripts/get-latest-unicode-script-values.js
+++ b/scripts/get-latest-unicode-script-values.js
@@ -1,0 +1,29 @@
+"use strict"
+
+const { fetchLines } = require("./fetch-lines")
+
+const DB_URL =
+    "https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"
+const logger = console
+
+module.exports = { getLatestUnicodeScriptValues }
+
+async function* getLatestUnicodeScriptValues() {
+    logger.log("Fetching data... (%s)", DB_URL)
+    for await (const line of fetchLines(DB_URL)) {
+        if (!line || line.startsWith("#")) {
+            continue
+        }
+        const [propertyAlias, alias, canonical, ...remaining] = line
+            .split("#")[0] // strip comments
+            .split(";") // split by semicolon
+            .map((x) => x.trim()) // trim
+        if (propertyAlias !== "sc") {
+            continue
+        }
+
+        yield alias
+        yield canonical
+        yield* remaining
+    }
+}

--- a/scripts/get-latest-unicode-script-values.js
+++ b/scripts/get-latest-unicode-script-values.js
@@ -1,29 +1,17 @@
 "use strict"
 
-const { fetchLines } = require("./fetch-lines")
-
-const DB_URL =
-    "https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"
-const logger = console
+const {
+    getLatestUnicodePropertyValues,
+} = require("./get-latest-unicode-property-values")
 
 module.exports = { getLatestUnicodeScriptValues }
 
 async function* getLatestUnicodeScriptValues() {
-    logger.log("Fetching data... (%s)", DB_URL)
-    for await (const line of fetchLines(DB_URL)) {
-        if (!line || line.startsWith("#")) {
-            continue
-        }
-        const [propertyAlias, alias, canonical, ...remaining] = line
-            .split("#")[0] // strip comments
-            .split(";") // split by semicolon
-            .map((x) => x.trim()) // trim
-        if (propertyAlias !== "sc") {
+    for await (const value of getLatestUnicodePropertyValues()) {
+        if (value.propertyAlias !== "sc") {
             continue
         }
 
-        yield alias
-        yield canonical
-        yield* remaining
+        yield* value.aliases
     }
 }

--- a/scripts/update-unicode-properties.js
+++ b/scripts/update-unicode-properties.js
@@ -4,6 +4,12 @@ const fs = require("fs")
 const path = require("path")
 const { JSDOM } = require("jsdom")
 const { ESLint } = require("eslint")
+const {
+    getLatestUnicodeGeneralCategoryValues,
+} = require("./get-latest-unicode-general-category-values")
+const {
+    getLatestUnicodeScriptValues,
+} = require("./get-latest-unicode-script-values")
 
 const DATA_SOURCES = [
     {
@@ -45,8 +51,8 @@ const DATA_SOURCES = [
         url: "https://tc39.es/ecma262/multipage/text-processing.html",
         version: 2023,
         binProperties: "#table-binary-unicode-properties",
-        gcValues: "#table-unicode-general-category-values",
-        scValues: "#table-unicode-script-values",
+        gcValues: getLatestUnicodeGeneralCategoryValues,
+        scValues: getLatestUnicodeScriptValues,
     },
 ]
 const FILE_PATH = path.resolve(__dirname, "../lib/util/unicode-properties.js")
@@ -91,13 +97,21 @@ const logger = console
         } while (window == null)
 
         logger.log("Parsing tables")
-        datum.binProperties = collectValues(
+        datum.binProperties = await collectValues(
             window,
             binProperties,
             existing.binProperties,
         )
-        datum.gcValues = collectValues(window, gcValues, existing.gcValues)
-        datum.scValues = collectValues(window, scValues, existing.scValues)
+        datum.gcValues = await collectValues(
+            window,
+            gcValues,
+            existing.gcValues,
+        )
+        datum.scValues = await collectValues(
+            window,
+            scValues,
+            existing.scValues,
+        )
 
         logger.log("Done")
     }
@@ -136,28 +150,51 @@ module.exports = {gcNameSet, scNameSet, gcValueSets, scValueSets, binPropertySet
     process.exitCode = 1
 })
 
-function collectValues(window, id, existingSet) {
-    const selector = `${id} td:nth-child(1) code`
-    const nodes = window.document.querySelectorAll(selector)
-    const values = Array.from(nodes, (node) => node.textContent || "")
-        .filter((value) => {
-            if (existingSet.has(value)) {
-                return false
-            }
-            existingSet.add(value)
-            return true
-        })
-        .sort(undefined)
+async function collectValues(window, idSelectorOrProvider, existingSet) {
+    const getValues =
+        typeof idSelectorOrProvider === "function"
+            ? idSelectorOrProvider
+            : function* () {
+                  const selector = `${idSelectorOrProvider} td:nth-child(1) code`
+                  const nodes = window.document.querySelectorAll(selector)
+                  if (nodes.length === 0) {
+                      throw new Error(`No nodes found for selector ${selector}`)
+                  }
+                  logger.log(
+                      "%o nodes of %o were found.",
+                      nodes.length,
+                      selector,
+                  )
+                  for (const node of Array.from(nodes)) {
+                      yield node.textContent ?? ""
+                  }
+              }
+
+    const missing = new Set(existingSet)
+    const values = new Set()
+    let allCount = 0
+
+    for await (const value of getValues()) {
+        allCount++
+        missing.delete(value)
+        if (existingSet.has(value)) {
+            continue
+        }
+        existingSet.add(value)
+        values.add(value)
+    }
+
+    if (missing.size > 0) {
+        throw new Error(`Missing values: ${Array.from(missing).join(", ")}`)
+    }
 
     logger.log(
-        "%o nodes of %o were found, then %o adopted and %o ignored as duplication.",
-        nodes.length,
-        selector,
-        values.length,
-        nodes.length - values.length,
+        "%o adopted and %o ignored as duplication.",
+        values.size,
+        allCount - values.size,
     )
 
-    return values
+    return [...values].sort(undefined)
 }
 
 function makeClassDeclarationCode(versions) {

--- a/scripts/update-unicode-properties.js
+++ b/scripts/update-unicode-properties.js
@@ -48,8 +48,15 @@ const DATA_SOURCES = [
         scValues: "#table-unicode-script-values",
     },
     {
-        url: "https://tc39.es/ecma262/multipage/text-processing.html",
+        url: "https://tc39.es/ecma262/2023/multipage/text-processing.html",
         version: 2023,
+        binProperties: "#table-binary-unicode-properties",
+        gcValues: getLatestUnicodeGeneralCategoryValues,
+        scValues: getLatestUnicodeScriptValues,
+    },
+    {
+        url: "https://tc39.es/ecma262/multipage/text-processing.html",
+        version: 2024,
         binProperties: "#table-binary-unicode-properties",
         gcValues: getLatestUnicodeGeneralCategoryValues,
         scValues: getLatestUnicodeScriptValues,

--- a/tests/lib/rules/no-regexp-unicode-property-escapes-2023.js
+++ b/tests/lib/rules/no-regexp-unicode-property-escapes-2023.js
@@ -1,0 +1,49 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-regexp-unicode-property-escapes-2023.js")
+
+if (!RuleTester.isSupported(2023)) {
+    //eslint-disable-next-line no-console
+    console.log("Skip the tests of no-regexp-unicode-property-escapes-2023.")
+    return
+}
+
+new RuleTester().run("no-regexp-unicode-property-escapes-2023", rule, {
+    valid: [
+        String.raw`/\p{Letter}/u`,
+        String.raw`/\P{Letter}/u`,
+        String.raw`/\p{Script=Hiragana}/u`,
+        String.raw`/\P{Script=Hiragana}/u`,
+        String.raw`/\p{Extended_Pictographic}/`,
+        String.raw`/\P{Extended_Pictographic}/`,
+        String.raw`/\p{Script=Dogr}/`,
+        String.raw`/\P{Script=Dogr}/`,
+        String.raw`new RegExp('\\p{Extended_Pictographic}')`,
+        String.raw`new RegExp('\\\\p{Extended_Pictographic}', 'u')`,
+        String.raw`/\p{Extended_Pictographic}/u`,
+        String.raw`/\p{Script=Dogr}/u`,
+        String.raw`/\p{Script=Elym}/u`,
+        String.raw`/\p{EBase}/u`,
+        String.raw`/\p{Script=Chorasmian}/u`,
+        String.raw`/\p{Script=Cpmn}/u`,
+    ],
+    invalid: [
+        {
+            code: String.raw`/\p{Script=Kawi}/u`,
+            errors: ["ES2023 '\\p{Script=Kawi}' is forbidden."],
+        },
+        {
+            code: String.raw`/\p{Script=Nag_Mundari}/u`,
+            errors: ["ES2023 '\\p{Script=Nag_Mundari}' is forbidden."],
+        },
+        {
+            code: String.raw`/\p{Script=Nagm}/u`,
+            errors: ["ES2023 '\\p{Script=Nagm}' is forbidden."],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds `es-x/no-regexp-unicode-property-escapes-2023` rule that disallow the new values of RegExp Unicode property escape sequences in ES2023.