### PR TITLE
Fix typo in `es-x/no-class-fields` error message

### DIFF
--- a/lib/rules/no-class-fields.js
+++ b/lib/rules/no-class-fields.js
@@ -54,7 +54,7 @@ module.exports = {
         },
         fixable: null,
         messages: {
-            forbidden: "ES2020 {{nameWithKind}} is forbidden.",
+            forbidden: "ES2022 {{nameWithKind}} is forbidden.",
         },
         schema: [],
         type: "problem",


### PR DESCRIPTION
While using `plugin:es-x/restrict-to-es2021`:

<img width="458" alt="Screenshot 2023-06-29 at 4 06 52 PM" src="https://github.com/eslint-community/eslint-plugin-es-x/assets/90871916/e93f821f-1004-4703-957f-6b6af8efeeaf">

And according to the documentation:

<img width="1055" alt="Screenshot 2023-06-29 at 4 08 20 PM" src="https://github.com/eslint-community/eslint-plugin-es-x/assets/90871916/a371be80-d7c5-4cea-905e-36675af429a0">
