### PR TITLE
Fix typo in `es-x/no-class-fields` error message

### DIFF
--- a/lib/rules/no-class-fields.js
+++ b/lib/rules/no-class-fields.js
@@ -54,7 +54,7 @@ module.exports = {
         },
         fixable: null,
         messages: {
-            forbidden: "ES2020 {{nameWithKind}} is forbidden.",
+            forbidden: "ES2022 {{nameWithKind}} is forbidden.",
         },
         schema: [],
         type: "problem",

--- a/tests/lib/rules/no-class-fields.js
+++ b/tests/lib/rules/no-class-fields.js
@@ -40,94 +40,94 @@ new RuleTester().run("no-class-fields", rule, {
     invalid: [
         {
             code: "class A { #foo() {} }",
-            errors: ["ES2020 private method #foo is forbidden."],
+            errors: ["ES2022 private method #foo is forbidden."],
         },
         {
             code: "class A { get #foo() {} }",
-            errors: ["ES2020 private getter #foo is forbidden."],
+            errors: ["ES2022 private getter #foo is forbidden."],
         },
         {
             code: "class A { set #foo(v) {} }",
-            errors: ["ES2020 private setter #foo is forbidden."],
+            errors: ["ES2022 private setter #foo is forbidden."],
         },
         {
             code: "class A { *#foo() {} }",
-            errors: ["ES2020 private generator method #foo is forbidden."],
+            errors: ["ES2022 private generator method #foo is forbidden."],
         },
         {
             code: "class A { async #foo() {} }",
-            errors: ["ES2020 private async method #foo is forbidden."],
+            errors: ["ES2022 private async method #foo is forbidden."],
         },
         {
             code: "class A { static #foo() {} }",
-            errors: ["ES2020 static private method #foo is forbidden."],
+            errors: ["ES2022 static private method #foo is forbidden."],
         },
         {
             code: "class A { static get #foo() {} }",
-            errors: ["ES2020 static private getter #foo is forbidden."],
+            errors: ["ES2022 static private getter #foo is forbidden."],
         },
         {
             code: "class A { static set #foo(v) {} }",
-            errors: ["ES2020 static private setter #foo is forbidden."],
+            errors: ["ES2022 static private setter #foo is forbidden."],
         },
         {
             code: "class A { static *#foo() {} }",
             errors: [
-                "ES2020 static private generator method #foo is forbidden.",
+                "ES2022 static private generator method #foo is forbidden.",
             ],
         },
         {
             code: "class A { static async #foo() {} }",
-            errors: ["ES2020 static private async method #foo is forbidden."],
+            errors: ["ES2022 static private async method #foo is forbidden."],
         },
 
         {
             code: "class A { foo }",
-            errors: ["ES2020 field 'foo' is forbidden."],
+            errors: ["ES2022 field 'foo' is forbidden."],
         },
         {
             code: "class A { foo = 42 }",
-            errors: ["ES2020 field 'foo' is forbidden."],
+            errors: ["ES2022 field 'foo' is forbidden."],
         },
         {
             code: "class A { static foo }",
-            errors: ["ES2020 static field 'foo' is forbidden."],
+            errors: ["ES2022 static field 'foo' is forbidden."],
         },
         {
             code: "class A { static foo = 42 }",
-            errors: ["ES2020 static field 'foo' is forbidden."],
+            errors: ["ES2022 static field 'foo' is forbidden."],
         },
         {
             code: "class A { [foo] }",
-            errors: ["ES2020 field [foo] is forbidden."],
+            errors: ["ES2022 field [foo] is forbidden."],
         },
         {
             code: "class A { [foo] = 42 }",
-            errors: ["ES2020 field [foo] is forbidden."],
+            errors: ["ES2022 field [foo] is forbidden."],
         },
         {
             code: "class A { static [foo] }",
-            errors: ["ES2020 static field [foo] is forbidden."],
+            errors: ["ES2022 static field [foo] is forbidden."],
         },
         {
             code: "class A { static [foo] = 42 }",
-            errors: ["ES2020 static field [foo] is forbidden."],
+            errors: ["ES2022 static field [foo] is forbidden."],
         },
         {
             code: "class A { #foo }",
-            errors: ["ES2020 private field #foo is forbidden."],
+            errors: ["ES2022 private field #foo is forbidden."],
         },
         {
             code: "class A { #foo = 42 }",
-            errors: ["ES2020 private field #foo is forbidden."],
+            errors: ["ES2022 private field #foo is forbidden."],
         },
         {
             code: "class A { static #foo }",
-            errors: ["ES2020 static private field #foo is forbidden."],
+            errors: ["ES2022 static private field #foo is forbidden."],
         },
         {
             code: "class A { static #foo = 42 }",
-            errors: ["ES2020 static private field #foo is forbidden."],
+            errors: ["ES2022 static private field #foo is forbidden."],
         },
         {
             code: `class A {
@@ -145,31 +145,31 @@ new RuleTester().run("no-class-fields", rule, {
             }`,
             errors: [
                 {
-                    message: "ES2020 private field #a is forbidden.",
+                    message: "ES2022 private field #a is forbidden.",
                     line: 2,
                 },
                 {
-                    message: "ES2020 private method #b is forbidden.",
+                    message: "ES2022 private method #b is forbidden.",
                     line: 3,
                 },
                 {
-                    message: "ES2020 private access #a is forbidden.",
+                    message: "ES2022 private access #a is forbidden.",
                     line: 6,
                 },
                 {
-                    message: "ES2020 private access #a is forbidden.",
+                    message: "ES2022 private access #a is forbidden.",
                     line: 7,
                 },
                 {
-                    message: "ES2020 private access #a is forbidden.",
+                    message: "ES2022 private access #a is forbidden.",
                     line: 8,
                 },
                 {
-                    message: "ES2020 private access #a is forbidden.",
+                    message: "ES2022 private access #a is forbidden.",
                     line: 9,
                 },
                 {
-                    message: "ES2020 private method call #b() is forbidden.",
+                    message: "ES2022 private method call #b() is forbidden.",
                     line: 11,
                 },
             ],
@@ -190,31 +190,31 @@ new RuleTester().run("no-class-fields", rule, {
             }`,
             errors: [
                 {
-                    message: "ES2020 static private field #c is forbidden.",
+                    message: "ES2022 static private field #c is forbidden.",
                     line: 2,
                 },
                 {
-                    message: "ES2020 static private field #d is forbidden.",
+                    message: "ES2022 static private field #d is forbidden.",
                     line: 3,
                 },
                 {
-                    message: "ES2020 private access #c is forbidden.",
+                    message: "ES2022 private access #c is forbidden.",
                     line: 6,
                 },
                 {
-                    message: "ES2020 private access #c is forbidden.",
+                    message: "ES2022 private access #c is forbidden.",
                     line: 7,
                 },
                 {
-                    message: "ES2020 private access #c is forbidden.",
+                    message: "ES2022 private access #c is forbidden.",
                     line: 8,
                 },
                 {
-                    message: "ES2020 private access #c is forbidden.",
+                    message: "ES2022 private access #c is forbidden.",
                     line: 9,
                 },
                 {
-                    message: "ES2020 private method call #d() is forbidden.",
+                    message: "ES2022 private method call #d() is forbidden.",
                     line: 11,
                 },
             ],


### PR DESCRIPTION
While using `plugin:es-x/restrict-to-es2021`:

<img width="458" alt="Screenshot 2023-06-29 at 4 06 52 PM" src="https://github.com/eslint-community/eslint-plugin-es-x/assets/90871916/e93f821f-1004-4703-957f-6b6af8efeeaf">

And according to the documentation:

<img width="1055" alt="Screenshot 2023-06-29 at 4 08 20 PM" src="https://github.com/eslint-community/eslint-plugin-es-x/assets/90871916/a371be80-d7c5-4cea-905e-36675af429a0">