### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,5 @@
 github:
 - eslint
 - ota-meshi
-- mysticatea
 open_collective: eslint
 tidelift: "npm/eslint"


### PR DESCRIPTION
I see no real reason to still suggest that people sponsor Mysticatea – and since GitHub picks this data up on https://github.com/sponsors/explore and ranks by the most mentioned developers this mention helps in getting Mysticatea to be one of the top users that GitHub suggests me to sponsor and that doesn't feel honest as any money to Mysticatea will evidently not help maintaining this module.

Do we have a policy on the mentioning of other accounts besides `eslint`? I don't mind having @ota-meshi in there, but would be good to treat all eslint-community projects the same.

Example from one of my orgs:

![Skärmavbild 2023-10-05 kl  23 43 01](https://github.com/eslint-community/eslint-plugin-es-x/assets/34457/271048b0-ef77-4da5-a018-59c7f7493b01)
