### PR TITLE
docs: fix double comma typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ export default [
         plugins: { "es-x": pluginESx },
         languageOptions: {
             ecmaVersion: 2018
-        },,
+        },
         rules: {
             "es-x/no-async-iteration": "error",
             "es-x/no-malformed-template-literals": "error",


### PR DESCRIPTION
Found this looking at the docs site. 🙂 