### PR TITLE
Add `no-atomics-pause` rule

### DIFF
--- a/.changeset/empty-turtles-attack.md
+++ b/.changeset/empty-turtles-attack.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-es-x": minor
+---
+
+Add `es-x/no-atomics-pause` rule

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -11,6 +11,7 @@ There is a config that enables the rules in this category: [`no-new-in-esnext`]
 | Rule ID | Description |    |
 |:--------|:------------|:--:|
 | [es-x/no-asyncdisposablestack](./no-asyncdisposablestack.md) | disallow the `AsyncDisposableStack` class. |  |
+| [es-x/no-atomics-pause](./no-atomics-pause.md) | disallow the `Atomics.pause` method. |  |
 | [es-x/no-date-prototype-totemporalinstant](./no-date-prototype-totemporalinstant.md) | disallow the `Date.prototype.toTemporalInstant` method. |  |
 | [es-x/no-disposablestack](./no-disposablestack.md) | disallow the `DisposableStack` class. |  |
 | [es-x/no-suppressederror](./no-suppressederror.md) | disallow the `SuppressedError` class. |  |

--- a/docs/rules/no-atomics-pause.md
+++ b/docs/rules/no-atomics-pause.md
@@ -1,0 +1,54 @@
+---
+title: "es-x/no-atomics-pause"
+description: "disallow the `Atomics.pause` method"
+---
+
+# es-x/no-atomics-pause
+> disallow the `Atomics.pause` method
+
+- ❗ <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- ✅ The following configurations enable this rule: [no-new-in-esnext]
+
+This rule reports ES2027 [`Atomics.pause` method](https://github.com/tc39/proposal-atomics-microwait) as errors.
+
+## 💡 Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad">
+
+```js
+/*eslint es-x/no-atomics-pause: [error] */
+Atomics.pause()
+```
+
+</eslint-playground>
+
+## 🔧 Options
+
+This rule has an option.
+
+```jsonc
+{
+  "rules": {
+    "es-x/no-atomics-pause": [
+      "error",
+      {
+        "allowTestedProperty": false
+      }
+    ]
+  }
+}
+```
+
+### allowTestedProperty: boolean
+
+Configure the allowTestedProperty mode for only this rule.
+This is prior to the `settings['es-x'].allowTestedProperty` setting.
+
+## 📚 References
+
+- [Rule source](https://github.com/eslint-community/eslint-plugin-es-x/blob/master/lib/rules/no-atomics-pause.js)
+- [Test source](https://github.com/eslint-community/eslint-plugin-es-x/blob/master/tests/lib/rules/no-atomics-pause.js)
+
+[no-new-in-esnext]: ../configs/index.md#no-new-in-esnext

--- a/lib/configs/flat/no-new-in-esnext.js
+++ b/lib/configs/flat/no-new-in-esnext.js
@@ -13,6 +13,7 @@ module.exports = {
     },
     rules: {
         "es-x/no-asyncdisposablestack": "error",
+        "es-x/no-atomics-pause": "error",
         "es-x/no-date-prototype-totemporalinstant": "error",
         "es-x/no-disposablestack": "error",
         "es-x/no-suppressederror": "error",

--- a/lib/configs/no-new-in-esnext.js
+++ b/lib/configs/no-new-in-esnext.js
@@ -8,6 +8,7 @@ module.exports = {
     plugins: ["es-x"],
     rules: {
         "es-x/no-asyncdisposablestack": "error",
+        "es-x/no-atomics-pause": "error",
         "es-x/no-date-prototype-totemporalinstant": "error",
         "es-x/no-disposablestack": "error",
         "es-x/no-suppressederror": "error",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -350,6 +350,7 @@ const plugin: {
         "no-async-iteration": require("./rules/no-async-iteration"),
         "no-asyncdisposablestack": require("./rules/no-asyncdisposablestack"),
         "no-atomics": require("./rules/no-atomics"),
+        "no-atomics-pause": require("./rules/no-atomics-pause"),
         "no-atomics-waitasync": require("./rules/no-atomics-waitasync"),
         "no-bigint": require("./rules/no-bigint"),
         "no-binary-numeric-literals": require("./rules/no-binary-numeric-literals"),

--- a/lib/rules/no-atomics-pause.js
+++ b/lib/rules/no-atomics-pause.js
@@ -1,0 +1,36 @@
+"use strict"
+
+const { createRule } = require("../util/create-rule")
+const {
+    defineStaticPropertiesHandler,
+} = require("../util/define-static-properties-handler")
+
+module.exports = createRule({
+    meta: {
+        docs: {
+            description: "disallow the `Atomics.pause` method.",
+            category: "ES2027",
+            recommended: false,
+            url: "https://eslint-community.github.io/eslint-plugin-es-x/rules/no-atomics-pause.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES2027 '{{name}}' method is forbidden.",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowTestedProperty: { type: "boolean" },
+                },
+                additionalProperties: false,
+            },
+        ],
+        type: "problem",
+    },
+    create(context) {
+        return defineStaticPropertiesHandler(context, {
+            Atomics: { pause: "function" },
+        })
+    },
+})

--- a/lib/util/well-known-properties.js
+++ b/lib/util/well-known-properties.js
@@ -1206,6 +1206,8 @@ const atomicsProperties = new Set([
     "notify",
     "xor",
     // [ %Symbol.toStringTag% ]
+
+    "pause",
 ])
 
 const jsonProperties = new Set([

--- a/tests/lib/rules/no-atomics-pause.ts
+++ b/tests/lib/rules/no-atomics-pause.ts
@@ -1,0 +1,12 @@
+import RuleTester from "../../tester"
+import * as rule from "../../../lib/rules/no-atomics-pause"
+
+new RuleTester().run("no-atomics-pause", rule, {
+    valid: ["Atomics", "Atomics.wait", "let Atomics = 0; Atomics.pause"],
+    invalid: [
+        {
+            code: "Atomics.pause",
+            errors: ["ES2027 'Atomics.pause' method is forbidden."],
+        },
+    ],
+})

--- a/tests/lib/rules/no-atomics-waitasync.ts
+++ b/tests/lib/rules/no-atomics-waitasync.ts
@@ -2,7 +2,7 @@ import RuleTester from "../../tester"
 import * as rule from "../../../lib/rules/no-atomics-waitasync"
 
 new RuleTester().run("no-atomics-waitasync", rule, {
-    valid: ["Atomics", "Atomics.wait", "let Atomics = 0; Atomics.watiAsync"],
+    valid: ["Atomics", "Atomics.wait", "let Atomics = 0; Atomics.waitAsync"],
     invalid: [
         {
             code: "Atomics.waitAsync",

--- a/tests/lib/util/well-known-properties.ts
+++ b/tests/lib/util/well-known-properties.ts
@@ -703,8 +703,6 @@ function* getAllProperties(object) {
             continue
         }
         if (
-            // https://github.com/tc39/proposal-atomics-microwait
-            (key === "pause" && object === Atomics) ||
             // https://github.com/tc39/proposal-error-capturestacktrace
             (key === "captureStackTrace" && object === Error) ||
             // https://github.com/tc39/proposal-json-parse-with-source


### PR DESCRIPTION
This PR adds a rule to the disallow method from the ES2027 `Atomics.pause()` proposal.

https://github.com/tc39/proposal-atomics-microwait