### PR TITLE
fix: crash for named export with ts in `es-x/no-nonstandard-*-prototype-properties` rules

### DIFF
--- a/lib/util/type-checker/object-type-checker-for-ts.js
+++ b/lib/util/type-checker/object-type-checker-for-ts.js
@@ -61,6 +61,9 @@ function buildObjectTypeCheckerForTS(context, aggressiveResult) {
 
         if (declarations) {
             for (const declaration of declarations) {
+                if (declaration.parent.kind === ts.SyntaxKind.SourceFile) {
+                    continue
+                }
                 const type = checker.getTypeAtLocation(declaration.parent)
                 if (type && typeEquals(type, className)) {
                     return true

--- a/tests/fixtures/test-module.ts
+++ b/tests/fixtures/test-module.ts
@@ -1,0 +1,1 @@
+export function fn() {}

--- a/tests/lib/rules/no-nonstandard-array-prototype-properties.js
+++ b/tests/lib/rules/no-nonstandard-array-prototype-properties.js
@@ -127,6 +127,10 @@ new RuleTester({
             filename,
             code: "let foo = /re/.exec('re'); foo.index",
         },
+        {
+            filename,
+            code: "import * as m from './test-module.js'; m.fn();",
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION


fixes #254