### PR TITLE
Improved `allowTestedProperty` option to allow more tested properties

### DIFF
--- a/lib/util/type-checker/property-guards.js
+++ b/lib/util/type-checker/property-guards.js
@@ -24,6 +24,7 @@ const TS_NODE_TYPES = [
  * @typedef {import("estree").ReturnStatement} ReturnStatement
  * @typedef {import("estree").ContinueStatement} ContinueStatement
  * @typedef {import("estree").BreakStatement} BreakStatement
+ * @typedef {import("estree").IfStatement} IfStatement
  * @typedef {import("estree").Node} Node
  * @typedef {import("eslint").SourceCode} SourceCode
  * @typedef {import("eslint").Rule.RuleContext} RuleContext
@@ -50,7 +51,7 @@ module.exports = { createPropertyGuardsContext }
 /**
  * @typedef {object} GuardChecker
  * @property {(node: MemberExpression|Property)=>boolean} test
- * @property {"instanceof"|"definedValue"|"definedType"|"hasValue"|"unknown"} kind
+ * @property {"instanceof"|"definedValue"|"definedType"|"hasValue"|"optional"|"unknown"} kind
  */
 /**
  * @typedef {object} MaybeGuard
@@ -251,6 +252,15 @@ function createPropertyGuardsContext(options) {
             }
             return null
         }
+        if (
+            ((parent.type === "CallExpression" && parent.callee === node) ||
+                (parent.type === "MemberExpression" &&
+                    parent.object === node)) &&
+            parent.optional
+        ) {
+            // e.g. x.property?.()
+            return { test: (n) => n === node, kind: "optional" }
+        }
 
         if (
             propertyTypes.every(
@@ -289,34 +299,52 @@ function createPropertyGuardsContext(options) {
             return getGuardCheckerForExpression(parent, { not: !not })
         }
         if (parent.type === "IfStatement" && parent.test === node) {
-            if (!not) {
-                const block = parent.consequent
-                return (n) =>
-                    block.range[0] <= n.range[0] && n.range[1] <= block.range[1]
-            }
-            // e.g. if (typeof x.property === 'undefined')
-            if (parent.alternate) {
-                const block = parent.alternate
-                return (n) =>
-                    block.range[0] <= n.range[0] && n.range[1] <= block.range[1]
-            }
-            if (!hasJumpStatementInAllPath(parent.consequent)) {
-                return null
-            }
-            /** @type {Node|null} */
-            const pp = getParent(parent)
-            if (
-                !pp ||
-                (pp.type !== "BlockStatement" && pp.type !== "Program")
-            ) {
-                return null
-            }
-            const start = parent.range[1]
-            const end = pp.range[1]
-
-            return (n) => start <= n.range[0] && n.range[1] <= end
+            return getGuardCheckerForIfStatement(parent, { not })
+        }
+        if (
+            !not &&
+            parent.type === "LogicalExpression" &&
+            parent.operator === "&&" &&
+            parent.left === node
+        ) {
+            // e.g. typeof x.property !== 'undefined' && x.property
+            const block = parent.right
+            return (n) =>
+                block.range[0] <= n.range[0] && n.range[1] <= block.range[1]
         }
         return null
+    }
+
+    /**
+     * @param {IfStatement} node
+     * @returns {((node: MemberExpression|Property)=>boolean)|null} The guard tester.
+     */
+    function getGuardCheckerForIfStatement(node, { not = false } = {}) {
+        if (!not) {
+            const block = node.consequent
+            return (n) =>
+                block.range[0] <= n.range[0] && n.range[1] <= block.range[1]
+        }
+        if (node.alternate) {
+            const block = node.alternate
+            return (n) =>
+                block.range[0] <= n.range[0] && n.range[1] <= block.range[1]
+        }
+        if (!hasJumpStatementInAllPath(node.consequent)) {
+            return null
+        }
+        /** @type {Node|null} */
+        const parent = getParent(node)
+        if (
+            !parent ||
+            (parent.type !== "BlockStatement" && parent.type !== "Program")
+        ) {
+            return null
+        }
+        const start = node.range[1]
+        const end = parent.range[1]
+
+        return (n) => start <= n.range[0] && n.range[1] <= end
     }
 
     /**
@@ -421,7 +449,7 @@ function createPropertyGuardsContext(options) {
             const guard = {
                 ...params,
                 prototypeGuard: isPrototypePropertyAccess(params.node),
-                used: false,
+                used: checker.kind === "optional",
                 isAvailableLocation: checker.test,
             }
             let classGuards = maybeGuards.get(params.className)

--- a/tests/lib/rules/no-array-from.js
+++ b/tests/lib/rules/no-array-from.js
@@ -24,6 +24,18 @@ new RuleTester().run("no-array-from", rule, {
             code: "if (Array.from) { const {from} = Array }",
             options: [{ allowTestedProperty: true }],
         },
+        {
+            code: "typeof Array.from !== 'undefined' && Array.from",
+            options: [{ allowTestedProperty: true }],
+        },
+        {
+            code: "Array.from && Array.from(it)",
+            options: [{ allowTestedProperty: true }],
+        },
+        {
+            code: "Array.from?.(it)",
+            options: [{ allowTestedProperty: true }],
+        },
     ],
     invalid: [
         {
@@ -44,6 +56,11 @@ new RuleTester().run("no-array-from", rule, {
         },
         {
             code: "if (Array.from) {  }",
+            options: [{ allowTestedProperty: true }],
+            errors: ["ES2015 'Array.from' method is forbidden."],
+        },
+        {
+            code: "Array?.from(it)",
             options: [{ allowTestedProperty: true }],
             errors: ["ES2015 'Array.from' method is forbidden."],
         },

--- a/tests/lib/rules/no-number-epsilon.js
+++ b/tests/lib/rules/no-number-epsilon.js
@@ -8,10 +8,23 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-number-epsilon.js")
 
 new RuleTester().run("no-number-epsilon", rule, {
-    valid: ["Number", "Number.xyz", "let Number = 0; Number.EPSILON"],
+    valid: [
+        "Number",
+        "Number.xyz",
+        "let Number = 0; Number.EPSILON",
+        {
+            code: "Number.EPSILON?.toString()",
+            options: [{ allowTestedProperty: true }],
+        },
+    ],
     invalid: [
         {
             code: "Number.EPSILON",
+            errors: ["ES2015 'Number.EPSILON' property is forbidden."],
+        },
+        {
+            code: "Number.EPSILON.toString?.()",
+            options: [{ allowTestedProperty: true }],
             errors: ["ES2015 'Number.EPSILON' property is forbidden."],
         },
     ],


### PR DESCRIPTION
This PR improves the `allowTestedProperty` option to allow more tested properties.

e.g. 

```js
x = typeof Array.from !== 'undefined' && Array.from(it) // OK
x = Array.from?.(it) // OK
```