### PR TITLE
Add `es-x/no-math-sumprecise` rule

### DIFF
--- a/.changeset/no-math-sumprecise.md
+++ b/.changeset/no-math-sumprecise.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-es-x": minor
+---
+
+Add `es-x/no-math-sumprecise` rule

--- a/docs/rules/no-math-sumprecise.md
+++ b/docs/rules/no-math-sumprecise.md
@@ -1,0 +1,39 @@
+# es-x/no-math-sumprecise
+> 
+
+This rule reports ES2026 [`Math.sumPrecise` property](https://github.com/tc39/proposal-math-sum) as errors.
+
+## 💡 Examples
+
+⛔ Examples of **incorrect** code for this rule:
+
+<eslint-playground type="bad">
+
+```js
+/*eslint es-x/no-math-sumprecise: error */
+Math.sumPrecise([1e20, 0.1, -1e20]);
+```
+
+</eslint-playground>
+
+## 🔧 Options
+
+This rule has an option.
+
+```jsonc
+{
+  "rules": {
+    "es-x/no-math-sumprecise": [
+      "error",
+      {
+        "allowTestedProperty": false
+      }
+    ]
+  }
+}
+```
+
+### allowTestedProperty: boolean
+
+Configure the allowTestedProperty mode for only this rule.
+This is prior to the `settings['es-x'].allowTestedProperty` setting.

--- a/lib/rules/no-math-sumprecise.js
+++ b/lib/rules/no-math-sumprecise.js
@@ -1,0 +1,35 @@
+"use strict"
+
+const {
+    defineStaticPropertiesHandler,
+} = require("../util/define-static-properties-handler")
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow the `Math.sumPrecise` method",
+            category: "ES2026",
+            recommended: false,
+            url: "http://eslint-community.github.io/eslint-plugin-es-x/rules/no-math-sumprecise.html",
+        },
+        fixable: null,
+        messages: {
+            forbidden: "ES2026 '{{name}}' method is forbidden.",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowTestedProperty: { type: "boolean" },
+                },
+                additionalProperties: false,
+            },
+        ],
+        type: "problem",
+    },
+    create(context) {
+        return defineStaticPropertiesHandler(context, {
+            Math: { sumPrecise: "function" },
+        })
+    },
+}

--- a/lib/util/well-known-properties.js
+++ b/lib/util/well-known-properties.js
@@ -248,6 +248,7 @@ const mathProperties = new Set([
     "sin",
     "sinh",
     "sqrt",
+    "sumPrecise",
     "tan",
     "tanh",
     "trunc",

--- a/scripts/new-rule.js
+++ b/scripts/new-rule.js
@@ -261,9 +261,10 @@ function buildStaticPropertiesRuleResources({ ruleId, object, properties }) {
     const exampleProperty = promptObject
         ? Object.getOwnPropertyNames(promptObject)[0]
         : "example"
-    const propertyType = promptObject
-        ? typeof promptObject[properties[0]]
-        : "function"
+    const propertyType =
+        promptObject && promptObject[properties[0]]
+            ? typeof promptObject[properties[0]]
+            : "function"
     const kind =
         propertyType === "function"
             ? ["method", "methods"]

--- a/tests/lib/rules/no-math-sumprecise.js
+++ b/tests/lib/rules/no-math-sumprecise.js
@@ -1,0 +1,14 @@
+"use strict"
+
+const RuleTester = require("../../tester")
+const rule = require("../../../lib/rules/no-math-sumprecise.js")
+
+new RuleTester().run("no-math-sumprecise", rule, {
+    valid: ["Math", "Math.abs", "let Math = 0; Math.sumPrecise"],
+    invalid: [
+        {
+            code: "Math.sumPrecise",
+            errors: ["ES2026 'Math.sumPrecise' method is forbidden."],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds a rule to the disallow method from the ES2026 `Math.sumPrecise()` proposal.

https://github.com/tc39/proposal-math-sum