### PR TITLE
Drop support for old Node.js versions

### DIFF
--- a/.changeset/drop-old-node.md
+++ b/.changeset/drop-old-node.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-es-x": major
+---
+
+Drop support for old Node.js (now supports `^20.19.0 || >=22.12.0`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,44 +28,30 @@ jobs:
       matrix:
         include:
           - eslint: 9
-            node: 20
+            node: 22
             os: ubuntu-latest
           # On other platforms
           - eslint: 9
-            node: 20
+            node: 22
             os: windows-latest
           - eslint: 9
-            node: 20
+            node: 22
             os: macos-latest
           # On other Node.js versions
-          - eslint: 8
-            node: 19
-            os: ubuntu-latest
-            tseslint: 7
           - eslint: 9
-            node: 18
+            node: 20
             os: ubuntu-latest
-          - eslint: 8
-            node: 16
+          - eslint: 9
+            node: 24
             os: ubuntu-latest
-            tseslint: 7
-          - eslint: 8
-            node: 17
-            os: ubuntu-latest
-            tseslint: 5
-          - eslint: 8
-            node: 14
-            os: ubuntu-latest
-            tseslint: 5
           # On old ESLint versions
-          - eslint: 8.0.0
-            node: 18
+          - eslint: 8
+            node: 22
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
           - eslint: 8.0.0
-            node: 14.18.0
+            node: 20.19.0
             os: ubuntu-latest
-            tseslint: 5
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: Install Packages
         run: npm install
       - name: Update

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ npm install --save-dev eslint eslint-plugin-es-x
 ```
 
 ::: tip Requirements
-- Node.js `14.18.0` or newer, except `15.x`.
+- Node.js `20.19.0`, `22.12.0` or newer.
 - ESLint `8.x` or newer.
 :::
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.7.0",
   "description": "ESLint plugin about ECMAScript syntactic features.",
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+		"node": "^20.19.0 || >=22.12.0"
   },
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.7.0",
   "description": "ESLint plugin about ECMAScript syntactic features.",
   "engines": {
-		"node": "^20.19.0 || >=22.12.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
This PR drops support for older Node.js versions.
The new supported versions are `^20.19.0 || >=22.12.0`.
This limits the versions to those that can use `require(esm)`. We are not using it yet, but we may use it during the development of this version.