### PR TITLE
Drop support for old ESLint

### DIFF
--- a/.changeset/drop-old-eslint.md
+++ b/.changeset/drop-old-eslint.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-es-x": major
+---
+
+Drop support for old ESLint (now supports `>=9.29.0`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,8 @@ jobs:
           - eslint: 9
             node: 24
             os: ubuntu-latest
-          # On old ESLint versions
-          - eslint: 8
-            node: 22
-            os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
-          - eslint: 8.0.0
+          - eslint: 9.29.0
             node: 20.19.0
             os: ubuntu-latest
 

--- a/docs/configs/index.md
+++ b/docs/configs/index.md
@@ -7,10 +7,6 @@ This plugin provides the following configs.
 disallow the new stuff to be planned for the next yearly ECMAScript snapshot.\
 ⚠️ This config will be changed in the minor versions of this plugin.
 
-### [Config (Flat Config)]
-
-eslint.config.js:
-
 ```js
 import pluginESx from "eslint-plugin-es-x"
 export default [
@@ -18,7 +14,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -28,13 +24,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2025
 
 disallow new stuff in ES2025.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -43,7 +37,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -53,13 +47,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2025-intl-api
 
 disallow new stuff in ES2025 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -68,7 +60,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -78,13 +70,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2024
 
 disallow new stuff in ES2024.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -93,7 +83,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -103,13 +93,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2023
 
 disallow new stuff in ES2023.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -118,7 +106,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -128,13 +116,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2023-intl-api
 
 disallow new stuff in ES2023 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -143,7 +129,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -153,13 +139,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2022
 
 disallow new stuff in ES2022.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -168,7 +152,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -178,13 +162,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2022-intl-api
 
 disallow new stuff in ES2022 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -193,7 +175,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -203,13 +185,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2021
 
 disallow new stuff in ES2021.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -218,7 +198,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -228,13 +208,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2021-intl-api
 
 disallow new stuff in ES2021 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -243,7 +221,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -253,13 +231,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2020
 
 disallow new stuff in ES2020.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -268,7 +244,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -278,13 +254,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2020-intl-api
 
 disallow new stuff in ES2020 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -293,7 +267,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -303,13 +277,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2019
 
 disallow new stuff in ES2019.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -318,7 +290,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -328,13 +300,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2018
 
 disallow new stuff in ES2018.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -343,7 +313,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -353,13 +323,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2018-intl-api
 
 disallow new stuff in ES2018 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -368,7 +336,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -378,13 +346,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2017
 
 disallow new stuff in ES2017.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -393,7 +359,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -403,13 +369,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2017-intl-api
 
 disallow new stuff in ES2017 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -418,7 +382,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -428,13 +392,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2016
 
 disallow new stuff in ES2016.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -443,7 +405,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -453,13 +415,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2016-intl-api
 
 disallow new stuff in ES2016 Intl API (ECMA-402).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -468,7 +428,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -478,13 +438,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es2015
 
 disallow new stuff in ES2015.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -493,7 +451,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -503,13 +461,11 @@ export default [
 }
 ```
 
+</details>
+
 ## no-new-in-es5
 
 disallow new stuff in ES5.
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -518,7 +474,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -528,13 +484,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2024
 
 disallow new stuff that ES2025 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -543,7 +497,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -553,13 +507,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2024-intl-api
 
 disallow new stuff that ES2025 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -568,7 +520,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -578,13 +530,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2023
 
 disallow new stuff that ES2024 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -593,7 +543,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -603,13 +553,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2023-intl-api
 
 disallow new stuff that ES2024 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -618,7 +566,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -628,13 +576,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2022
 
 disallow new stuff that ES2023 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -643,7 +589,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -653,13 +599,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2022-intl-api
 
 disallow new stuff that ES2023 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -668,7 +612,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -678,13 +622,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2021
 
 disallow new stuff that ES2022 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -693,7 +635,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -703,13 +645,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2021-intl-api
 
 disallow new stuff that ES2022 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -718,7 +658,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -728,13 +668,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2020
 
 disallow new stuff that ES2021 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -743,7 +681,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -753,13 +691,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2020-intl-api
 
 disallow new stuff that ES2021 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -768,7 +704,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -778,13 +714,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2019
 
 disallow new stuff that ES2020 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -793,7 +727,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -803,13 +737,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2019-intl-api
 
 disallow new stuff that ES2020 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -818,7 +750,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -828,13 +760,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2018
 
 disallow new stuff that ES2019 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -843,7 +773,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -853,13 +783,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2018-intl-api
 
 disallow new stuff that ES2019 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -868,7 +796,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -878,13 +806,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2017
 
 disallow new stuff that ES2018 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -893,7 +819,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -903,13 +829,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2017-intl-api
 
 disallow new stuff that ES2018 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -918,7 +842,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -928,13 +852,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2016
 
 disallow new stuff that ES2017 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -943,7 +865,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -953,13 +875,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2016-intl-api
 
 disallow new stuff that ES2017 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -968,7 +888,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -978,13 +898,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2015
 
 disallow new stuff that ES2016 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -993,7 +911,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1003,13 +921,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es2015-intl-api
 
 disallow new stuff that ES2016 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1018,7 +934,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1028,13 +944,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es5
 
 disallow new stuff that ES2015 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1043,7 +957,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1053,13 +967,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es-intl-api-1st-edition
 
 disallow new stuff that ES2015 Intl API (ECMA-402) doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1068,7 +980,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1078,13 +990,11 @@ export default [
 }
 ```
 
+</details>
+
 ## restrict-to-es3
 
 disallow new stuff that ES5 doesn't include
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1093,7 +1003,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1103,16 +1013,14 @@ export default [
 }
 ```
 
+</details>
+
 ## no-explicit-resource-management
 
 disallow proposal ES2026 [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management)\
 ⚠️ This config will be changed in the minor versions of this plugin.
 
 This configs includes rules for [es-x/no-asyncdisposablestack](../rules/no-asyncdisposablestack.md), [es-x/no-disposablestack](../rules/no-disposablestack.md), [es-x/no-suppressederror](../rules/no-suppressederror.md), [es-x/no-symbol-asyncdispose](../rules/no-symbol-asyncdispose.md), [es-x/no-symbol-dispose](../rules/no-symbol-dispose.md), and [es-x/no-using-declarations](../rules/no-using-declarations.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1121,7 +1029,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1131,15 +1039,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-float16array
 
 disallow proposal ES2025 [Float16Array](https://github.com/tc39/proposal-float16array)
 
 This configs includes rules for [es-x/no-dataview-prototype-getfloat16-setfloat16](../rules/no-dataview-prototype-getfloat16-setfloat16.md), [es-x/no-float16array](../rules/no-float16array.md), and [es-x/no-math-f16round](../rules/no-math-f16round.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1148,7 +1054,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1158,15 +1064,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-import-attributes
 
 disallow proposal ES2025 [Import Attributes](https://github.com/tc39/proposal-import-attributes)
 
 This configs includes rules for [es-x/no-dynamic-import-options](../rules/no-dynamic-import-options.md), [es-x/no-import-attributes](../rules/no-import-attributes.md), and [es-x/no-trailing-dynamic-import-commas](../rules/no-trailing-dynamic-import-commas.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1175,7 +1079,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1185,15 +1089,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-iterator-helpers
 
 disallow proposal ES2025 [Iterator Helpers](https://github.com/tc39/proposal-iterator-helpers)
 
 This configs includes rules for [es-x/no-iterator-prototype-drop](../rules/no-iterator-prototype-drop.md), [es-x/no-iterator-prototype-every](../rules/no-iterator-prototype-every.md), [es-x/no-iterator-prototype-filter](../rules/no-iterator-prototype-filter.md), [es-x/no-iterator-prototype-find](../rules/no-iterator-prototype-find.md), [es-x/no-iterator-prototype-flatmap](../rules/no-iterator-prototype-flatmap.md), [es-x/no-iterator-prototype-foreach](../rules/no-iterator-prototype-foreach.md), [es-x/no-iterator-prototype-map](../rules/no-iterator-prototype-map.md), [es-x/no-iterator-prototype-reduce](../rules/no-iterator-prototype-reduce.md), [es-x/no-iterator-prototype-some](../rules/no-iterator-prototype-some.md), [es-x/no-iterator-prototype-take](../rules/no-iterator-prototype-take.md), [es-x/no-iterator-prototype-toarray](../rules/no-iterator-prototype-toarray.md), and [es-x/no-iterator](../rules/no-iterator.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1202,7 +1104,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1212,15 +1114,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-set-methods
 
 disallow proposal ES2025 [Set Methods for JavaScript](https://github.com/tc39/proposal-set-methods)
 
 This configs includes rules for [es-x/no-set-prototype-difference](../rules/no-set-prototype-difference.md), [es-x/no-set-prototype-intersection](../rules/no-set-prototype-intersection.md), [es-x/no-set-prototype-isdisjointfrom](../rules/no-set-prototype-isdisjointfrom.md), [es-x/no-set-prototype-issubsetof](../rules/no-set-prototype-issubsetof.md), [es-x/no-set-prototype-issupersetof](../rules/no-set-prototype-issupersetof.md), [es-x/no-set-prototype-symmetricdifference](../rules/no-set-prototype-symmetricdifference.md), and [es-x/no-set-prototype-union](../rules/no-set-prototype-union.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1229,7 +1129,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1239,15 +1139,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-array-grouping
 
 disallow proposal ES2024 [Array Grouping](https://github.com/tc39/proposal-array-grouping)
 
 This configs includes rules for [es-x/no-map-groupby](../rules/no-map-groupby.md) and [es-x/no-object-groupby](../rules/no-object-groupby.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1256,7 +1154,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1266,15 +1164,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-is-usv-string
 
 disallow proposal ES2024 [Well-Formed Unicode Strings](https://github.com/tc39/proposal-is-usv-string)
 
 This configs includes rules for [es-x/no-string-prototype-iswellformed](../rules/no-string-prototype-iswellformed.md) and [es-x/no-string-prototype-towellformed](../rules/no-string-prototype-towellformed.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1283,7 +1179,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1293,15 +1189,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-change-array-by-copy
 
 disallow proposal ES2023 [Change Array by Copy](https://github.com/tc39/proposal-change-array-by-copy)
 
 This configs includes rules for [es-x/no-array-prototype-toreversed](../rules/no-array-prototype-toreversed.md), [es-x/no-array-prototype-tosorted](../rules/no-array-prototype-tosorted.md), [es-x/no-array-prototype-tospliced](../rules/no-array-prototype-tospliced.md), and [es-x/no-array-prototype-with](../rules/no-array-prototype-with.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1310,7 +1204,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1320,15 +1214,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-intl-numberformat-v3
 
 disallow proposal ES2023 Intl API [Intl.NumberFormat V3](https://github.com/tc39/proposal-intl-numberformat-v3)
 
 This configs includes rules for [es-x/no-intl-numberformat-prototype-formatrange](../rules/no-intl-numberformat-prototype-formatrange.md), [es-x/no-intl-numberformat-prototype-formatrangetoparts](../rules/no-intl-numberformat-prototype-formatrangetoparts.md), and [es-x/no-intl-pluralrules-prototype-selectrange](../rules/no-intl-pluralrules-prototype-selectrange.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1337,7 +1229,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1347,15 +1239,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-class-fields
 
 disallow proposal ES2022 [Class Fields](https://github.com/tc39/proposal-class-fields)
 
 This configs includes rules for [es-x/no-class-instance-fields](../rules/no-class-instance-fields.md), [es-x/no-class-private-fields](../rules/no-class-private-fields.md), [es-x/no-class-private-methods](../rules/no-class-private-methods.md), and [es-x/no-class-static-fields](../rules/no-class-static-fields.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1364,7 +1254,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1374,15 +1264,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-relative-indexing-method
 
 disallow proposal ES2022 [An .at() method on all the built-in indexables](https://github.com/tc39/proposal-relative-indexing-method)
 
 This configs includes rules for [es-x/no-array-prototype-at](../rules/no-array-prototype-at.md) and [es-x/no-string-prototype-at](../rules/no-string-prototype-at.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1391,7 +1279,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1401,15 +1289,13 @@ export default [
 }
 ```
 
+</details>
+
 ## no-string-matchall
 
 disallow proposal ES2020 [String.prototype.matchAll](https://github.com/tc39/proposal-string-matchall)
 
 This configs includes rules for [es-x/no-string-prototype-matchall](../rules/no-string-prototype-matchall.md) and [es-x/no-symbol-matchall](../rules/no-symbol-matchall.md).
-
-### [Config (Flat Config)]
-
-eslint.config.js:
 
 ```js
 import pluginESx from "eslint-plugin-es-x"
@@ -1418,7 +1304,7 @@ export default [
 ]
 ```
 
-### [Legacy Config]
+<details><summary> Legacy Config </summary>
 
 .eslintrc.*:
 
@@ -1427,6 +1313,8 @@ export default [
     "extends": ["plugin:es-x/no-string-matchall"],
 }
 ```
+
+</details>
 
 [Config (Flat Config)]: https://eslint.org/docs/latest/use/configure/configuration-files
 [Legacy Config]: https://eslint.org/docs/latest/use/configure/configuration-files-deprecated

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ npm install --save-dev eslint eslint-plugin-es-x
 
 ::: tip Requirements
 - Node.js `20.19.0`, `22.12.0` or newer.
-- ESLint `8.x` or newer.
+- ESLint `9.29.0` or newer.
 :::
 
 ## 📖 Usage

--- a/docs/rules/no-string-prototype-iswellformed-towellformed.md
+++ b/docs/rules/no-string-prototype-iswellformed-towellformed.md
@@ -23,7 +23,7 @@ This rule reports ES2024 [`String.prototype.{isWellFormed,toWellFormed}` methods
 "str".toWellFormed()
 ```
 
-</eslint-playground>a
+</eslint-playground>
 
 ## 🔧 Options
 

--- a/eslint-internal/rules/es-x-rule/require-aggressive-schema.js
+++ b/eslint-internal/rules/es-x-rule/require-aggressive-schema.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const { ReferenceTracker, READ } = require("@eslint-community/eslint-utils")
-const { getSourceCode, getFilename } = require("eslint-compat-utils")
 const path = require("path")
 const {
     defineSchemaChecker,
@@ -28,7 +27,7 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         const tracker = new ReferenceTracker(
             sourceCode.getScope(sourceCode.ast),
@@ -42,7 +41,7 @@ module.exports = {
             }).map(([filePath, properties]) => {
                 const absolutePath = path.join(__dirname, "../../..", filePath)
                 const relativePath = path.relative(
-                    path.dirname(getFilename(context)),
+                    path.dirname(context.filename),
                     absolutePath,
                 )
                 return [relativePath, properties]

--- a/eslint-internal/rules/es-x-rule/require-allow-schema.js
+++ b/eslint-internal/rules/es-x-rule/require-allow-schema.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const { ReferenceTracker, READ } = require("@eslint-community/eslint-utils")
-const { getSourceCode, getFilename } = require("eslint-compat-utils")
 const path = require("path")
 const {
     defineSchemaChecker,
@@ -28,7 +27,7 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         const tracker = new ReferenceTracker(
             sourceCode.getScope(sourceCode.ast),
@@ -47,7 +46,7 @@ module.exports = {
             }).map(([filePath, properties]) => {
                 const absolutePath = path.join(__dirname, "../../..", filePath)
                 const relativePath = path.relative(
-                    path.dirname(getFilename(context)),
+                    path.dirname(context.filename),
                     absolutePath,
                 )
                 return [relativePath, properties]

--- a/eslint-internal/rules/es-x-rule/require-allow-tested-property-schema.js
+++ b/eslint-internal/rules/es-x-rule/require-allow-tested-property-schema.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const { ReferenceTracker, READ } = require("@eslint-community/eslint-utils")
-const { getSourceCode, getFilename } = require("eslint-compat-utils")
 const path = require("path")
 const {
     defineSchemaChecker,
@@ -28,7 +27,7 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         const tracker = new ReferenceTracker(
             sourceCode.getScope(sourceCode.ast),
@@ -53,7 +52,7 @@ module.exports = {
             }).map(([filePath, properties]) => {
                 const absolutePath = path.join(__dirname, "../../..", filePath)
                 const relativePath = path.relative(
-                    path.dirname(getFilename(context)),
+                    path.dirname(context.filename),
                     absolutePath,
                 )
                 return [relativePath, properties]

--- a/eslint-internal/rules/my-block-scoped-var.js
+++ b/eslint-internal/rules/my-block-scoped-var.js
@@ -5,8 +5,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -207,7 +205,7 @@ module.exports = {
         type: "suggestion",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * Finds and reports references which are outside of valid scopes.

--- a/eslint-internal/rules/my-no-instanceof-array.js
+++ b/eslint-internal/rules/my-no-instanceof-array.js
@@ -5,8 +5,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -24,7 +22,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * Checks whether the given node is RHS of instanceof.

--- a/eslint-internal/rules/my-no-instanceof-wrapper.js
+++ b/eslint-internal/rules/my-no-instanceof-wrapper.js
@@ -5,8 +5,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -24,7 +22,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         const targetTypes = [
             "Boolean",
             "Number",

--- a/eslint-internal/rules/my-no-this-in-static.js
+++ b/eslint-internal/rules/my-no-this-in-static.js
@@ -5,8 +5,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -24,7 +22,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         let funcInfo = null
 
         /**

--- a/eslint-internal/rules/my-no-use-ignored-vars.js
+++ b/eslint-internal/rules/my-no-use-ignored-vars.js
@@ -4,8 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -30,7 +28,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         const ignorePattern =
             context.options[0] != null
                 ? new RegExp(context.options[0], "u")

--- a/eslint-internal/rules/my-no-useless-rest-spread.js
+++ b/eslint-internal/rules/my-no-useless-rest-spread.js
@@ -4,8 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -108,7 +106,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * Verify the given SpreadElement or RestElement.

--- a/eslint-internal/rules/my-prefer-for-of.js
+++ b/eslint-internal/rules/my-prefer-for-of.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const assert = require("assert")
-const { getSourceCode } = require("eslint-compat-utils")
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -92,7 +91,7 @@ function isSimpleReference(node) {
  * @returns {boolean} `true` if the node is called recursively.
  */
 function isCalledRecursively(context, node) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     return (
         node.id != null &&
         sourceCode.getDeclaredVariables(node)[0].references.length > 0
@@ -223,7 +222,7 @@ function isAssignee(startNode) {
  * used to get array elements.
  */
 function isIndexVarOnlyUsedToGetArrayElements(context, node) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const arrayText = getArrayTextOfForStatement(sourceCode, node)
     const indexVar = sourceCode.getDeclaredVariables(node.init)[0]
 
@@ -254,7 +253,7 @@ function isLengthVarOnlyUsedToTest(context, node) {
     if (node.init.declarations.length !== 2) {
         return true
     }
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const lengthVar = sourceCode.getDeclaredVariables(
         node.init.declarations[1],
     )[0]
@@ -322,7 +321,7 @@ function getContextVariable(context, contextNode) {
     }
     assert(node.type === "Identifier")
 
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const scope = sourceCode.getScope(contextNode).upper
     return scope.set.get(node.name) || null
 }
@@ -414,7 +413,7 @@ function applyFixes(originalText, fixes) {
  * @returns {Fix|null} The created fix object.
  */
 function fixArrayForEach(context, callbackInfo, fixer) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const funcNode = callbackInfo.node
     const callNode = funcNode.parent
     const calleeNode = callNode.callee
@@ -463,7 +462,7 @@ function fixArrayForEach(context, callbackInfo, fixer) {
  * @returns {Fix|null} The created fix object.
  */
 function fixForStatement(context, node, fixer) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const element = getElementVariableDeclaration(sourceCode, node)
 
     // Cannot fix if element name is unknown.
@@ -578,7 +577,7 @@ module.exports = {
                     // verify whether the reference gets the context variable or not.
                     if (thisFuncInfo.canReplaceAllThis) {
                         if (thisFuncInfo.contextVar != null) {
-                            const sourceCode = getSourceCode(context)
+                            const sourceCode = context.sourceCode
                             const variable = getVariableByName(
                                 sourceCode.getScope(node),
                                 thisFuncInfo.contextVar.name,

--- a/eslint-internal/utils/schema-checker.js
+++ b/eslint-internal/utils/schema-checker.js
@@ -4,7 +4,6 @@ const {
     getPropertyName,
     getStaticValue,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import("estree").Node} Node
@@ -18,7 +17,7 @@ const { getSourceCode } = require("eslint-compat-utils")
  * @param {(propertiesNode: ObjectExpression) => void} check
  */
 function defineSchemaChecker(context, check) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     return {
         // eslint-disable-next-line complexity
         MemberExpression(node) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,22 +26,22 @@ const config = [
                 {
                     object: "context",
                     property: "getSourceCode",
-                    message: "Use eslint-compat-utils",
+                    message: "Use context.sourceCode",
                 },
                 {
                     object: "context",
                     property: "getFilename",
-                    message: "Use eslint-compat-utils",
+                    message: "Use context.filename",
                 },
                 {
                     object: "context",
                     property: "getPhysicalFilename",
-                    message: "Use eslint-compat-utils",
+                    message: "Use context.physicalFilename",
                 },
                 {
                     object: "context",
                     property: "getCwd",
-                    message: "Use eslint-compat-utils",
+                    message: "Use context.cwd",
                 },
                 {
                     object: "context",

--- a/lib/rules/no-arrow-functions.js
+++ b/lib/rules/no-arrow-functions.js
@@ -8,7 +8,6 @@ const {
     isArrowToken,
     isParenthesized,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 module.exports = {
     meta: {
@@ -26,7 +25,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * ArrowFunctionExpression to FunctionExpression

--- a/lib/rules/no-class-instance-fields.js
+++ b/lib/rules/no-class-instance-fields.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getFieldName } = require("../utils")
 
 module.exports = {
@@ -38,7 +37,7 @@ module.exports = {
                     data: {
                         nameWithKind: [
                             "instance field",
-                            getFieldName(node, getSourceCode(context)),
+                            getFieldName(node, context.sourceCode),
                         ]
                             .filter(Boolean)
                             .join(" "),

--- a/lib/rules/no-class-private-fields.js
+++ b/lib/rules/no-class-private-fields.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getFieldName } = require("../utils")
 
 module.exports = {
@@ -44,7 +43,7 @@ module.exports = {
                         data: {
                             nameWithKind: [
                                 "private field",
-                                getFieldName(parent, getSourceCode(context)),
+                                getFieldName(parent, context.sourceCode),
                             ]
                                 .filter(Boolean)
                                 .join(" "),

--- a/lib/rules/no-class-private-methods.js
+++ b/lib/rules/no-class-private-methods.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getFieldName } = require("../utils")
 
 module.exports = {
@@ -35,7 +34,7 @@ module.exports = {
                     data: {
                         nameWithKind: [
                             "private method",
-                            getFieldName(node, getSourceCode(context)),
+                            getFieldName(node, context.sourceCode),
                         ]
                             .filter(Boolean)
                             .join(" "),

--- a/lib/rules/no-class-static-fields.js
+++ b/lib/rules/no-class-static-fields.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getFieldName } = require("../utils")
 
 module.exports = {
@@ -38,7 +37,7 @@ module.exports = {
                     data: {
                         nameWithKind: [
                             "static field",
-                            getFieldName(node, getSourceCode(context)),
+                            getFieldName(node, context.sourceCode),
                         ]
                             .filter(Boolean)
                             .join(" "),

--- a/lib/rules/no-error-cause.js
+++ b/lib/rules/no-error-cause.js
@@ -11,7 +11,6 @@ const {
     ReferenceTracker,
     getPropertyName,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import("estree").Node} Node
@@ -80,7 +79,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         /** @type {Array<{ classNode: ClassNode, superCallNode: CallExpression }>} */
         const maybeErrorSubclasses = []
 

--- a/lib/rules/no-hashbang.js
+++ b/lib/rules/no-hashbang.js
@@ -1,7 +1,5 @@
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 module.exports = {
     meta: {
         docs: {
@@ -20,7 +18,7 @@ module.exports = {
     create(context) {
         return {
             Program() {
-                const firstComment = getSourceCode(context).ast.comments[0]
+                const firstComment = context.sourceCode.ast.comments[0]
                 if (firstComment && firstComment.type === "Shebang") {
                     context.report({
                         node: firstComment,

--- a/lib/rules/no-import-attributes.js
+++ b/lib/rules/no-import-attributes.js
@@ -4,7 +4,6 @@ const {
     findVariable,
     getPropertyName,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import("estree").Expression} Expression
@@ -28,7 +27,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /** @param {Expression} optionsNode  */
         function findImportAttributeFromOptions(optionsNode) {

--- a/lib/rules/no-json-modules.js
+++ b/lib/rules/no-json-modules.js
@@ -5,7 +5,6 @@ const {
     findVariable,
     getStaticValue,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import('estree').ImportAttribute} ImportAttribute
@@ -41,7 +40,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         function findProperty(node, name) {
             for (const prop of node.properties) {

--- a/lib/rules/no-json-superset.js
+++ b/lib/rules/no-json-superset.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { definePatternSearchGenerator } = require("../utils")
 const iterateTargetChars = definePatternSearchGenerator(/[\u2028\u2029]/gu)
 
@@ -24,7 +23,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             Literal(node) {
                 if (typeof node.value !== "string") {

--- a/lib/rules/no-legacy-object-prototype-accessor-methods.js
+++ b/lib/rules/no-legacy-object-prototype-accessor-methods.js
@@ -4,7 +4,6 @@ const {
     getPropertyName,
     findVariable,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 const LEGACY_ACCESSOR_METHODS = new Set([
     "__defineGetter__",
@@ -72,7 +71,7 @@ module.exports = {
                 ) {
                     return
                 }
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const scopeManager = sourceCode.scopeManager
                 if (
                     // Not defined as global variables.

--- a/lib/rules/no-logical-assignment-operators.js
+++ b/lib/rules/no-logical-assignment-operators.js
@@ -5,7 +5,6 @@
 "use strict"
 
 const utils = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 module.exports = {
     meta: {
@@ -23,7 +22,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             "AssignmentExpression[operator=/(?:\\|\\||&&|\\?\\?)=/]"(node) {
                 const operatorToken = sourceCode.getTokenAfter(node.left)

--- a/lib/rules/no-nullish-coalescing-operators.js
+++ b/lib/rules/no-nullish-coalescing-operators.js
@@ -4,8 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 /**
  * Checks if the given token is a nullish coalescing operator or not.
  * @param {Token} token - The token to check.
@@ -34,7 +32,7 @@ module.exports = {
         return {
             "LogicalExpression[operator='??']"(node) {
                 context.report({
-                    node: getSourceCode(context).getTokenAfter(
+                    node: context.sourceCode.getTokenAfter(
                         node.left,
                         isNullishCoalescingOperator,
                     ),

--- a/lib/rules/no-optional-chaining.js
+++ b/lib/rules/no-optional-chaining.js
@@ -4,8 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 module.exports = {
     meta: {
         docs: {
@@ -22,7 +20,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * Checks if the given token is a `?.` token or not.

--- a/lib/rules/no-property-shorthands.js
+++ b/lib/rules/no-property-shorthands.js
@@ -8,7 +8,6 @@ const {
     isOpeningBracketToken,
     isClosingBracketToken,
 } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 module.exports = {
     meta: {
@@ -26,7 +25,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * Fixes a FunctionExpression node by making it into a longform property.

--- a/lib/rules/no-regexp-d-flag.js
+++ b/lib/rules/no-regexp-d-flag.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getRegExpCalls } = require("../utils")
 
 module.exports = {
@@ -31,7 +30,7 @@ module.exports = {
             },
 
             "Program:exit"(program) {
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const scope = sourceCode.getScope(program)
 
                 for (const { node, flags } of getRegExpCalls(scope)) {

--- a/lib/rules/no-regexp-duplicate-named-capturing-groups.js
+++ b/lib/rules/no-regexp-duplicate-named-capturing-groups.js
@@ -1,6 +1,5 @@
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { defineRegExpHandler } = require("../util/define-regexp-handler")
 
 module.exports = {
@@ -43,7 +42,7 @@ module.exports = {
                             continue
                         }
                         const { start, end } = dupe
-                        const sourceCode = getSourceCode(context)
+                        const sourceCode = context.sourceCode
                         context.report({
                             node,
                             loc:

--- a/lib/rules/no-regexp-modifiers.js
+++ b/lib/rules/no-regexp-modifiers.js
@@ -1,6 +1,5 @@
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { defineRegExpHandler } = require("../util/define-regexp-handler")
 
 module.exports = {
@@ -30,7 +29,7 @@ module.exports = {
                 },
                 onExit() {
                     for (const { start, end } of found) {
-                        const sourceCode = getSourceCode(context)
+                        const sourceCode = context.sourceCode
                         context.report({
                             node,
                             loc:

--- a/lib/rules/no-regexp-s-flag.js
+++ b/lib/rules/no-regexp-s-flag.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getRegExpCalls } = require("../utils")
 
 module.exports = {
@@ -31,7 +30,7 @@ module.exports = {
             },
 
             "Program:exit"(program) {
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const scope = sourceCode.getScope(program)
 
                 for (const { node, flags } of getRegExpCalls(scope)) {

--- a/lib/rules/no-regexp-u-flag.js
+++ b/lib/rules/no-regexp-u-flag.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getRegExpCalls } = require("../utils")
 
 module.exports = {
@@ -31,7 +30,7 @@ module.exports = {
             },
 
             "Program:exit"(program) {
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const scope = sourceCode.getScope(program)
 
                 for (const { node, flags } of getRegExpCalls(scope)) {

--- a/lib/rules/no-regexp-v-flag.js
+++ b/lib/rules/no-regexp-v-flag.js
@@ -1,6 +1,5 @@
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getRegExpCalls } = require("../utils")
 
 module.exports = {
@@ -27,7 +26,7 @@ module.exports = {
             },
 
             "Program:exit"(program) {
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const scope = sourceCode.getScope(program)
 
                 for (const { node, flags } of getRegExpCalls(scope)) {

--- a/lib/rules/no-regexp-y-flag.js
+++ b/lib/rules/no-regexp-y-flag.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { getRegExpCalls } = require("../utils")
 
 module.exports = {
@@ -31,7 +30,7 @@ module.exports = {
             },
 
             "Program:exit"(program) {
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const scope = sourceCode.getScope(program)
 
                 for (const { node, flags } of getRegExpCalls(scope)) {

--- a/lib/rules/no-resizable-and-growable-arraybuffers.js
+++ b/lib/rules/no-resizable-and-growable-arraybuffers.js
@@ -8,7 +8,6 @@ const {
 const {
     definePrototypePropertiesHandler,
 } = require("../util/define-prototype-properties-handler")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @param {Node|undefined} node
@@ -74,7 +73,7 @@ module.exports = {
             ),
             {
                 "Program:exit"(program) {
-                    const sourceCode = getSourceCode(context)
+                    const sourceCode = context.sourceCode
                     const tracker = new ReferenceTracker(
                         sourceCode.getScope(program),
                     )

--- a/lib/rules/no-shadow-catch-param.js
+++ b/lib/rules/no-shadow-catch-param.js
@@ -1,7 +1,5 @@
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 module.exports = {
     meta: {
         docs: {
@@ -19,7 +17,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             "CatchClause > Identifier.param:exit"(node) {
                 const scope = sourceCode.getScope(node)

--- a/lib/rules/no-subclassing-builtins.js
+++ b/lib/rules/no-subclassing-builtins.js
@@ -5,7 +5,6 @@
 "use strict"
 
 const { READ, ReferenceTracker } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 module.exports = {
     meta: {
@@ -25,7 +24,7 @@ module.exports = {
     create(context) {
         return {
             "Program:exit"(program) {
-                const sourceCode = getSourceCode(context)
+                const sourceCode = context.sourceCode
                 const tracker = new ReferenceTracker(
                     sourceCode.getScope(program),
                 )

--- a/lib/rules/no-template-literals.js
+++ b/lib/rules/no-template-literals.js
@@ -4,8 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
-
 /**
  * Checks whether it is string literal
  * @param  {string} s string source code
@@ -60,7 +58,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             "TaggedTemplateExpression, :not(TaggedTemplateExpression) > TemplateLiteral"(
                 node,

--- a/lib/rules/no-trailing-commas.js
+++ b/lib/rules/no-trailing-commas.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { isCommaToken } = require("../utils")
 
 module.exports = {
@@ -24,7 +23,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             "ArrayExpression, ArrayPattern, ObjectExpression, ObjectPattern"(
                 node,

--- a/lib/rules/no-trailing-dynamic-import-commas.js
+++ b/lib/rules/no-trailing-dynamic-import-commas.js
@@ -1,6 +1,5 @@
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { isCommaToken } = require("../utils")
 
 module.exports = {
@@ -20,7 +19,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             ImportExpression(node) {
                 const lastParam = node.options || node.source

--- a/lib/rules/no-trailing-function-commas.js
+++ b/lib/rules/no-trailing-function-commas.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { isCommaToken } = require("../utils")
 
 module.exports = {
@@ -25,7 +24,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
         return {
             ":function"(node) {
                 const length = node.params.length

--- a/lib/rules/no-unicode-codepoint-escapes.js
+++ b/lib/rules/no-unicode-codepoint-escapes.js
@@ -4,7 +4,6 @@
  */
 "use strict"
 
-const { getSourceCode } = require("eslint-compat-utils")
 const { definePatternSearchGenerator } = require("../utils")
 const codePointEscapeSearchGenerator =
     definePatternSearchGenerator(/\\u\{[0-9a-fA-F]+\}/gu)
@@ -35,7 +34,7 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        const sourceCode = getSourceCode(context)
+        const sourceCode = context.sourceCode
 
         /**
          * find code point escape, and report

--- a/lib/util/define-globals-handler/index.js
+++ b/lib/util/define-globals-handler/index.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const { ReferenceTracker, READ } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import("eslint").Rule.RuleContext} RuleContext
@@ -13,7 +12,7 @@ const { getSourceCode } = require("eslint-compat-utils")
  * @returns {Record<string, (node: ASTNode) => void>} The defined handlers.
  */
 function defineGlobalsHandler(context, names) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     return {
         "Program:exit"(program) {
             const tracker = new ReferenceTracker(sourceCode.getScope(program))

--- a/lib/util/define-nonstandard-prototype-properties-handler/index.js
+++ b/lib/util/define-nonstandard-prototype-properties-handler/index.js
@@ -5,7 +5,6 @@ const { getPropertyKeyValue } = require("../get-property-key-value")
 const {
     createPropertyGuardsContext,
 } = require("../type-checker/property-guards")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import("estree").MemberExpression} MemberExpression
@@ -25,7 +24,7 @@ function defineNonstandardPrototypePropertiesHandler(
     nameMap,
     options,
 ) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
 
     const objectTypeChecker = buildTypeChecker(sourceCode)
 

--- a/lib/util/define-nonstandard-static-properties-handler/index.js
+++ b/lib/util/define-nonstandard-static-properties-handler/index.js
@@ -5,7 +5,6 @@ const {
     createPropertyGuardsContext,
 } = require("../type-checker/property-guards")
 const { ReferenceTracker, READ } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 /**
  * @typedef {import("estree").MemberExpression} MemberExpression
@@ -22,7 +21,7 @@ function defineNonstandardStaticPropertiesHandler(context, nameMap) {
         ([className, propertyNames]) =>
             /** @type {const} */ ([className, new Set(propertyNames)]),
     )
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
 
     const guardsContext = createPropertyGuardsContext({ context })
 

--- a/lib/util/define-prototype-properties-handler/index.js
+++ b/lib/util/define-prototype-properties-handler/index.js
@@ -4,7 +4,7 @@ const { getPropertyName } = require("@eslint-community/eslint-utils")
 const {
     createPropertyGuardsContext,
 } = require("../type-checker/property-guards")
-const { getSourceCode } = require("eslint-compat-utils")
+
 const { buildTypeChecker } = require("eslint-type-tracer")
 
 /**
@@ -40,7 +40,7 @@ const { buildTypeChecker } = require("eslint-type-tracer")
  * @returns {Record<string, (node: Node) => void>} The defined handlers.
  */
 function definePrototypePropertiesHandler(context, propertyTypeMap, options) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const aggressiveOption = getAggressiveOption(context)
 
     const objectTypeChecker = buildTypeChecker(sourceCode, {

--- a/lib/util/define-regexp-handler.js
+++ b/lib/util/define-regexp-handler.js
@@ -2,7 +2,6 @@
 
 const { RegExpValidator } = require("@eslint-community/regexpp")
 const { getRegExpCalls } = require("../utils")
-const { getSourceCode } = require("eslint-compat-utils")
 
 const allVisitorBuilder = new WeakMap()
 
@@ -16,7 +15,7 @@ const allVisitorBuilder = new WeakMap()
  * @returns {Record<string, (node: ASTNode) => void>} The defined handlers.
  */
 function defineRegExpHandler(context, visitorBuilder) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     const programNode = sourceCode.ast
 
     let handler = {}

--- a/lib/util/define-static-properties-handler/index.js
+++ b/lib/util/define-static-properties-handler/index.js
@@ -1,7 +1,7 @@
 "use strict"
 
 const { ReferenceTracker, READ } = require("@eslint-community/eslint-utils")
-const { getSourceCode } = require("eslint-compat-utils")
+
 const {
     createPropertyGuardsContext,
 } = require("../type-checker/property-guards")
@@ -23,7 +23,7 @@ const {
  * @returns {Record<string, (node: ASTNode) => void>} The defined handlers.
  */
 function defineStaticPropertiesHandler(context, propertyTypeMap) {
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
 
     const guardsContext = createPropertyGuardsContext({
         context,

--- a/lib/util/type-checker/property-guards.js
+++ b/lib/util/type-checker/property-guards.js
@@ -1,7 +1,7 @@
 "use strict"
 
 const { getPropertyKeyValue } = require("../get-property-key-value")
-const { getSourceCode } = require("eslint-compat-utils")
+
 const {
     findVariable,
     getStaticValue,
@@ -93,7 +93,7 @@ function createPropertyGuardsContext(options) {
             },
         }
     }
-    const sourceCode = getSourceCode(context)
+    const sourceCode = context.sourceCode
     /** @type {PropertyTypeMap} */
     const propertyTypeMap = {}
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.1.2",
     "@eslint-community/regexpp": "^4.12.1",
-    "eslint-compat-utils": "^0.6.3",
     "eslint-type-tracer": "^0.4.0"
   },
   "devDependencies": {
@@ -24,7 +23,7 @@
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@typescript-eslint/parser": "^8.0.0",
     "env-cmd": "^10.1.0",
-    "eslint": "^9.1.0",
+    "eslint": "^9.29.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^6.0.0",
     "eslint-plugin-n": "^17.8.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "eslint": ">=8"
+    "eslint": ">=9.29.0"
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.1.2",

--- a/scripts/update-docs-configs.js
+++ b/scripts/update-docs-configs.js
@@ -67,13 +67,6 @@ Object.values(configs)
     )
     .forEach(processCategoryConfig)
 
-contents.push(
-    "[Config (Flat Config)]: https://eslint.org/docs/latest/use/configure/configuration-files",
-)
-contents.push(
-    "[Legacy Config]: https://eslint.org/docs/latest/use/configure/configuration-files-deprecated",
-)
-
 fs.writeFileSync(MD_PATH, `${contents.join("\n").trim()}\n`)
 
 /**
@@ -131,10 +124,6 @@ function processCategoryConfig({
 }
 
 function appendConfig(configName) {
-    contents.push("### [Config (Flat Config)]")
-    contents.push("")
-    contents.push("eslint.config.js:")
-    contents.push("")
     contents.push("```js")
     contents.push(`import pluginESx from "eslint-plugin-es-x"
 export default [
@@ -142,7 +131,7 @@ export default [
 ]`)
     contents.push("```")
     contents.push("")
-    contents.push("### [Legacy Config]")
+    contents.push("<details><summary> Legacy Config </summary>")
     contents.push("")
     contents.push(".eslintrc.*:")
     contents.push("")
@@ -151,6 +140,8 @@ export default [
     "extends": ["plugin:es-x/${configName}"],
 }`)
     contents.push("```")
+    contents.push("")
+    contents.push("</details>")
     contents.push("")
 }
 

--- a/tests/lib/rules/no-arbitrary-module-namespace-names.js
+++ b/tests/lib/rules/no-arbitrary-module-namespace-names.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-arbitrary-module-namespace-names.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-arbitrary-module-namespace-names.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-arbitrary-module-namespace-names", rule, {

--- a/tests/lib/rules/no-bigint.js
+++ b/tests/lib/rules/no-bigint.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-bigint.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-bigint.")
-    return
-}
-
 new RuleTester().run("no-bigint", rule, {
     valid: ["100"],
     invalid: [

--- a/tests/lib/rules/no-class-fields.js
+++ b/tests/lib/rules/no-class-fields.js
@@ -8,12 +8,6 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-class-fields.js")
 const ruleId = "no-class-fields"
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-class-fields.")
-    return
-}
-
 new RuleTester().run(ruleId, rule, {
     valid: [
         "class A {}",

--- a/tests/lib/rules/no-class-instance-fields.js
+++ b/tests/lib/rules/no-class-instance-fields.js
@@ -8,12 +8,6 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-class-instance-fields.js")
 const ruleId = "no-class-instance-fields"
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-class-instance-fields.")
-    return
-}
-
 new RuleTester().run(ruleId, rule, {
     valid: [
         "class A {}",

--- a/tests/lib/rules/no-class-private-fields.js
+++ b/tests/lib/rules/no-class-private-fields.js
@@ -8,12 +8,6 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-class-private-fields.js")
 const ruleId = "no-class-private-fields"
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-class-private-fields.")
-    return
-}
-
 new RuleTester().run(ruleId, rule, {
     valid: [
         "class A {}",

--- a/tests/lib/rules/no-class-private-methods.js
+++ b/tests/lib/rules/no-class-private-methods.js
@@ -8,12 +8,6 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-class-private-methods.js")
 const ruleId = "no-class-private-methods"
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-class-private-methods.")
-    return
-}
-
 new RuleTester().run(ruleId, rule, {
     valid: [
         "class A {}",

--- a/tests/lib/rules/no-class-static-block.js
+++ b/tests/lib/rules/no-class-static-block.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-class-static-block.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-class-static-block.")
-    return
-}
-
 new RuleTester().run("no-class-static-block", rule, {
     valid: ["class A { static f() {} }", "class A { static get f() {} }"],
     invalid: [

--- a/tests/lib/rules/no-class-static-fields.js
+++ b/tests/lib/rules/no-class-static-fields.js
@@ -8,12 +8,6 @@ const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-class-static-fields.js")
 const ruleId = "no-class-static-fields"
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-class-static-fields.")
-    return
-}
-
 new RuleTester().run(ruleId, rule, {
     valid: [
         "class A {}",

--- a/tests/lib/rules/no-dynamic-import-options.js
+++ b/tests/lib/rules/no-dynamic-import-options.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-dynamic-import-options.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-dynamic-import-options.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-dynamic-import-options", rule, {

--- a/tests/lib/rules/no-dynamic-import.js
+++ b/tests/lib/rules/no-dynamic-import.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-dynamic-import.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-dynamic-import.")
-    return
-}
-
 new RuleTester().run("no-dynamic-import", rule, {
     valid: [
         {

--- a/tests/lib/rules/no-error-cause.js
+++ b/tests/lib/rules/no-error-cause.js
@@ -8,12 +8,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-error-cause.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-error-cause.")
-    return
-}
-
 const errorConstructorNames = [
     "Error",
     "AggregateError",

--- a/tests/lib/rules/no-export-ns-from.js
+++ b/tests/lib/rules/no-export-ns-from.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-export-ns-from.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-export-ns-from.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-export-ns-from", rule, {

--- a/tests/lib/rules/no-global-this.js
+++ b/tests/lib/rules/no-global-this.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-global-this.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-global-this.")
-    return
-}
-
 new RuleTester().run("no-global-this", rule, {
     valid: ["window", "global", "self", "{ let globalThis = 0; globalThis }"],
     invalid: [

--- a/tests/lib/rules/no-hashbang.js
+++ b/tests/lib/rules/no-hashbang.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-hashbang.js")
 
-if (!RuleTester.isSupported(2023)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-hashbang.")
-    return
-}
-
 new RuleTester().run("no-hashbang", rule, {
     valid: [
         "/* comment */",

--- a/tests/lib/rules/no-import-attributes.js
+++ b/tests/lib/rules/no-import-attributes.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-import-attributes.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-import-attributes.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-import-attributes", rule, {

--- a/tests/lib/rules/no-import-meta.js
+++ b/tests/lib/rules/no-import-meta.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-import-meta.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-import-meta.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-import-meta", rule, {

--- a/tests/lib/rules/no-iterator.js
+++ b/tests/lib/rules/no-iterator.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-iterator.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-iterator.")
-    return
-}
-
 new RuleTester({
     languageOptions: { globals: { Iterator: "readonly" } },
 }).run("no-iterator", rule, {

--- a/tests/lib/rules/no-json-modules.js
+++ b/tests/lib/rules/no-json-modules.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-json-modules.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-json-modules.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-json-modules", rule, {

--- a/tests/lib/rules/no-json-superset.js
+++ b/tests/lib/rules/no-json-superset.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-json-superset.js")
 
-if (!RuleTester.isSupported(2019)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-json-superset.")
-    return
-}
-
 new RuleTester().run("no-json-superset", rule, {
     valid: [
         "let a = null",

--- a/tests/lib/rules/no-logical-assignment-operators.js
+++ b/tests/lib/rules/no-logical-assignment-operators.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-logical-assignment-operators.js")
 
-if (!RuleTester.isSupported(2021)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-logical-assignment-operators.")
-    return
-}
-
 new RuleTester().run("no-logical-assignment-operators", rule, {
     valid: [
         "x = x || y",

--- a/tests/lib/rules/no-nullish-coalescing-operators.js
+++ b/tests/lib/rules/no-nullish-coalescing-operators.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-nullish-coalescing-operators.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-nullish-coalescing-operators.")
-    return
-}
-
 new RuleTester().run("no-nullish-coalescing-operators", rule, {
     valid: ["a ? b : c", "a && b", "a || b"],
     invalid: [

--- a/tests/lib/rules/no-numeric-separators.js
+++ b/tests/lib/rules/no-numeric-separators.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-numeric-separators.js")
 
-if (!RuleTester.isSupported(2021)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-numeric-separators.")
-    return
-}
-
 new RuleTester().run("no-numeric-separators", rule, {
     valid: [
         "123456",

--- a/tests/lib/rules/no-optional-catch-binding.js
+++ b/tests/lib/rules/no-optional-catch-binding.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-optional-catch-binding.js")
 
-if (!RuleTester.isSupported(2019)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-optional-catch-binding.")
-    return
-}
-
 new RuleTester().run("no-optional-catch-binding", rule, {
     valid: ["try {} catch (err) {}"],
     invalid: [

--- a/tests/lib/rules/no-optional-chaining.js
+++ b/tests/lib/rules/no-optional-chaining.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-optional-chaining.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-optional-chaining.")
-    return
-}
-
 new RuleTester().run("no-optional-chaining", rule, {
     valid: ["var x = a.b", "var x = a[b]", "foo()"],
     invalid: [

--- a/tests/lib/rules/no-private-in.js
+++ b/tests/lib/rules/no-private-in.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-private-in.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-private-in.")
-    return
-}
-
 new RuleTester().run("no-private-in", rule, {
     valid: [
         "class A { f(obj) { return '#x' in obj } }",

--- a/tests/lib/rules/no-promise-all-settled.js
+++ b/tests/lib/rules/no-promise-all-settled.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-promise-all-settled.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-promise-all-settled.")
-    return
-}
-
 new RuleTester().run("no-promise-all-settled", rule, {
     valid: ["Promise.all"],
     invalid: [

--- a/tests/lib/rules/no-regexp-d-flag.js
+++ b/tests/lib/rules/no-regexp-d-flag.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-d-flag.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-d-flag.")
-    return
-}
-
 new RuleTester().run("no-regexp-d-flag", rule, {
     valid: [
         "/foo/gimuys",

--- a/tests/lib/rules/no-regexp-duplicate-named-capturing-groups.js
+++ b/tests/lib/rules/no-regexp-duplicate-named-capturing-groups.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-duplicate-named-capturing-groups.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-duplicate-named-capturing-groups.")
-    return
-}
-
 new RuleTester().run("no-regexp-duplicate-named-capturing-groups", rule, {
     valid: [
         String.raw`/(?<x>a)/`,

--- a/tests/lib/rules/no-regexp-modifiers.js
+++ b/tests/lib/rules/no-regexp-modifiers.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-modifiers.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-modifiers.")
-    return
-}
-
 new RuleTester().run("no-regexp-modifiers", rule, {
     valid: [
         String.raw`/(a)/i`,

--- a/tests/lib/rules/no-regexp-unicode-property-escapes-2019.js
+++ b/tests/lib/rules/no-regexp-unicode-property-escapes-2019.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-unicode-property-escapes-2019.js")
 
-if (!RuleTester.isSupported(2019)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-unicode-property-escapes-2019.")
-    return
-}
-
 new RuleTester().run("no-regexp-unicode-property-escapes-2019", rule, {
     valid: [
         String.raw`/\p{Letter}/u`,

--- a/tests/lib/rules/no-regexp-unicode-property-escapes-2020.js
+++ b/tests/lib/rules/no-regexp-unicode-property-escapes-2020.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-unicode-property-escapes-2020.js")
 
-if (!RuleTester.isSupported(2020)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-unicode-property-escapes-2020.")
-    return
-}
-
 new RuleTester().run("no-regexp-unicode-property-escapes-2020", rule, {
     valid: [
         String.raw`/\p{Letter}/u`,

--- a/tests/lib/rules/no-regexp-unicode-property-escapes-2021.js
+++ b/tests/lib/rules/no-regexp-unicode-property-escapes-2021.js
@@ -13,11 +13,6 @@ if (semver.lt(RuleTester.eslintVersion, "8.0.0")) {
     console.log("Skip the tests of no-regexp-unicode-property-escapes-2021.")
     return
 }
-if (!RuleTester.isSupported(2021)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-unicode-property-escapes-2021.")
-    return
-}
 
 new RuleTester().run("no-regexp-unicode-property-escapes-2021", rule, {
     valid: [

--- a/tests/lib/rules/no-regexp-unicode-property-escapes-2022.js
+++ b/tests/lib/rules/no-regexp-unicode-property-escapes-2022.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-unicode-property-escapes-2022.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-unicode-property-escapes-2022.")
-    return
-}
-
 new RuleTester().run("no-regexp-unicode-property-escapes-2022", rule, {
     valid: [
         String.raw`/\p{Letter}/u`,

--- a/tests/lib/rules/no-regexp-unicode-property-escapes-2023.js
+++ b/tests/lib/rules/no-regexp-unicode-property-escapes-2023.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-unicode-property-escapes-2023.js")
 
-if (!RuleTester.isSupported(2023)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-unicode-property-escapes-2023.")
-    return
-}
-
 new RuleTester().run("no-regexp-unicode-property-escapes-2023", rule, {
     valid: [
         String.raw`/\p{Letter}/u`,

--- a/tests/lib/rules/no-regexp-v-flag.js
+++ b/tests/lib/rules/no-regexp-v-flag.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-regexp-v-flag.js")
 
-if (!RuleTester.isSupported(2024)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-regexp-v-flag.")
-    return
-}
-
 new RuleTester().run("no-regexp-v-flag", rule, {
     valid: [
         "/foo/gimsu",

--- a/tests/lib/rules/no-top-level-await.js
+++ b/tests/lib/rules/no-top-level-await.js
@@ -7,12 +7,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-top-level-await.js")
 
-if (!RuleTester.isSupported(2022)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-top-level-await.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-top-level-await", rule, {

--- a/tests/lib/rules/no-trailing-dynamic-import-commas.js
+++ b/tests/lib/rules/no-trailing-dynamic-import-commas.js
@@ -3,12 +3,6 @@
 const RuleTester = require("../../tester")
 const rule = require("../../../lib/rules/no-trailing-dynamic-import-commas.js")
 
-if (!RuleTester.isSupported(2025)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of no-trailing-dynamic-import-commas.")
-    return
-}
-
 new RuleTester({
     languageOptions: { sourceType: "module" },
 }).run("no-trailing-dynamic-import-commas", rule, {

--- a/tests/lib/util/define-regexp-handler.js
+++ b/tests/lib/util/define-regexp-handler.js
@@ -1,21 +1,13 @@
 "use strict"
 
-const RuleTester = require("../../tester")
 const path = require("path")
 const assert = require("assert")
 const plugin = require("../../..")
-const { getESLint } = require("eslint-compat-utils/eslint")
-const ESLint = getESLint()
+const { ESLint } = require("eslint")
 
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
-
-if (!RuleTester.isSupported(2019)) {
-    //eslint-disable-next-line no-console
-    console.log("Skip the tests of define-regexp-handler.")
-    return
-}
 
 const TEST_CWD = path.join(__dirname, "../fixtures/integrations/eslint-plugin")
 

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -5,22 +5,15 @@
 "use strict"
 
 const { Linter } = require("eslint")
-const { getRuleTester } = require("eslint-compat-utils/rule-tester")
+const { RuleTester } = require("eslint")
 const { builtin } = require("globals")
 const semver = require("semver")
-const RuleTester = getRuleTester()
 
 const eslintVersion = new Linter().version
 const ecmaVersion =
     /*eslint-disable prettier/prettier */
-    semver.gte(eslintVersion, "9.6.0") ? 2025 :
-    semver.gte(eslintVersion, "8.44.0") ? 2024 :
-    semver.gte(eslintVersion, "8.23.0") ? 2023 :
-    semver.gte(eslintVersion, "8.0.0") ? 2022 :
-    semver.gte(eslintVersion, "7.8.0") ? 2021 :
-    semver.gte(eslintVersion, "6.2.0") ? 2020 :
-    semver.gte(eslintVersion, "5.0.0") ? 2019 :
-    2018
+    semver.gte(eslintVersion, "9.29.0") ? 2026 :
+    2025
     /*eslint-enable prettier/prettier */
 
 //eslint-disable-next-line no-console


### PR DESCRIPTION
This PR drops support for the old ESLint.
The new supported version is `>=9.29.0`.
This means that we are limited to versions that can use `ES2026`.


---


We need to merge #271 first.