### PR TITLE
Drop support for old ESLint versions. The peer dependency now supports `>=10.6.0`.

### DIFF
--- a/.changeset/drop-old-eslint-support.md
+++ b/.changeset/drop-old-eslint-support.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-es-x": major
+---
+
+Drop support for old ESLint versions. The peer dependency now supports `>=10.6.0`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,30 +27,26 @@ jobs:
     strategy:
       matrix:
         include:
-          - eslint: 9
+          - eslint: 10
             node: 24.18.0
             os: ubuntu-latest
           # On other platforms
-          - eslint: 9
+          - eslint: 10
             node: 24.18.0
             os: windows-latest
-          - eslint: 9
+          - eslint: 10
             node: 24.18.0
             os: macos-latest
           # On other Node.js versions
-          - eslint: 9
+          - eslint: 10
             node: 22.23.0
             os: ubuntu-latest
-          - eslint: 9
+          - eslint: 10
             node: 26.4.0
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
-          - eslint: 9.29.0
+          - eslint: 10.6.0
             node: 22.23.0
-            os: ubuntu-latest
-          # On ESLint 10
-          - eslint: 10
-            node: 24.18.0
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "node": "^22.23.0 || ^24.18.0 || >=26.4.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.29.0"
+        "eslint": ">=10.6.0"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "eslint": ">=9.29.0"
+    "eslint": ">=10.6.0"
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.1.2",


### PR DESCRIPTION


<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Drop support for old ESLint versions and raise the minimum supported ESLint version to `10.6.0`.

#### What changes did you make? (Give an overview)

- Updated `peerDependencies.eslint` from `>=9.29.0` to `>=10.6.0`.
- Refreshed the root `package-lock.json` peer dependency metadata.
- Updated the CI matrix to remove ESLint 9 coverage and run supported Node/platform coverage against ESLint 10.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
