### PR TITLE
chore: use `import.meta.dirname` in ESM files

### DIFF
--- a/scripts/new-rule.ts
+++ b/scripts/new-rule.ts
@@ -53,9 +53,18 @@ async function main(ruleId: string | undefined) {
         return
     }
 
-    const testFile = path.resolve(__dirname, `../tests/lib/rules/${ruleId}.ts`)
-    const docFile = path.resolve(__dirname, `../docs/rules/${ruleId}.md`)
-    const changesetFile = path.resolve(__dirname, `../.changeset/${ruleId}.md`)
+    const testFile = path.resolve(
+        import.meta.dirname,
+        `../tests/lib/rules/${ruleId}.ts`,
+    )
+    const docFile = path.resolve(
+        import.meta.dirname,
+        `../docs/rules/${ruleId}.md`,
+    )
+    const changesetFile = path.resolve(
+        import.meta.dirname,
+        `../.changeset/${ruleId}.md`,
+    )
 
     prompts.intro("Create the new rule!")
 
@@ -231,7 +240,10 @@ async function main(ruleId: string | undefined) {
     const resources =
         BUILDERS[kind]?.(resourceOptions) ??
         buildDefaultResources(resourceOptions)
-    const ruleFile = path.resolve(__dirname, `../lib/rules/${ruleId}.ts`)
+    const ruleFile = path.resolve(
+        import.meta.dirname,
+        `../lib/rules/${ruleId}.ts`,
+    )
 
     fs.writeFileSync(ruleFile, resources.rule)
     fs.writeFileSync(testFile, resources.test)
@@ -629,7 +641,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 
@@ -1010,7 +1022,7 @@ ${
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/scripts/rules.ts
+++ b/scripts/rules.ts
@@ -10,7 +10,7 @@ import { createJiti } from "jiti"
 
 const jiti = createJiti(import.meta.url, {})
 
-const libRoot = path.resolve(__dirname, "../lib/rules")
+const libRoot = path.resolve(import.meta.dirname, "../lib/rules")
 const requireRule = jiti
 
 export interface Rule {

--- a/scripts/update-docs-configs.ts
+++ b/scripts/update-docs-configs.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import { getConfigCategories, type Category } from "./rules.ts"
 
-const MD_PATH = path.resolve(__dirname, "../docs/configs/index.md")
+const MD_PATH = path.resolve(import.meta.dirname, "../docs/configs/index.md")
 const listFormatter = new Intl.ListFormat("en", { type: "conjunction" })
 
 const contents = [

--- a/scripts/update-docs-rules.ts
+++ b/scripts/update-docs-rules.ts
@@ -40,8 +40,8 @@ function toRuleLink(ruleId: string) {
 }
 
 async function main() {
-    const docsRoot = path.resolve(__dirname, "../docs/rules/")
-    const configRoot = path.resolve(__dirname, "../lib/configs/flat")
+    const docsRoot = path.resolve(import.meta.dirname, "../docs/rules/")
+    const configRoot = path.resolve(import.meta.dirname, "../lib/configs/flat")
     const configs = await Promise.all(
         fs.globSync("*.ts", { cwd: configRoot }).map(async (filename) => {
             const configName = path.basename(filename, ".ts")

--- a/scripts/update-lib-flat-configs.ts
+++ b/scripts/update-lib-flat-configs.ts
@@ -10,7 +10,7 @@ import {
     getConfigCategoriesForAboveConfig,
 } from "./rules.ts"
 
-const Root = path.resolve(__dirname, "../lib/configs/flat")
+const Root = path.resolve(import.meta.dirname, "../lib/configs/flat")
 
 function wrapCode(code: string, imports = "") {
     return `/**

--- a/scripts/update-lib-index.ts
+++ b/scripts/update-lib-index.ts
@@ -9,7 +9,10 @@ import { rules } from "./rules.ts"
 
 const collator = new Intl.Collator("en", { numeric: true })
 
-const flatConfigRootPath = path.resolve(__dirname, "../lib/configs/flat")
+const flatConfigRootPath = path.resolve(
+    import.meta.dirname,
+    "../lib/configs/flat",
+)
 const configIds = getConfigIds(flatConfigRootPath)
 const ruleIds = rules.map((r) => r.ruleId).sort(collator.compare.bind(collator))
 

--- a/scripts/update-unicode-properties.ts
+++ b/scripts/update-unicode-properties.ts
@@ -71,7 +71,10 @@ const DATA_SOURCES = [
         scValues: getLatestUnicodeScriptValues,
     },
 ]
-const FILE_PATH = path.resolve(__dirname, "../lib/util/unicode-properties.ts")
+const FILE_PATH = path.resolve(
+    import.meta.dirname,
+    "../lib/util/unicode-properties.ts",
+)
 const logger = console
 
 // Main

--- a/tests/lib/rules/no-array-prototype-at.ts
+++ b/tests/lib/rules/no-array-prototype-at.ts
@@ -68,7 +68,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-copywithin.ts
+++ b/tests/lib/rules/no-array-prototype-copywithin.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-entries.ts
+++ b/tests/lib/rules/no-array-prototype-entries.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-every.ts
+++ b/tests/lib/rules/no-array-prototype-every.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-fill.ts
+++ b/tests/lib/rules/no-array-prototype-fill.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-filter.ts
+++ b/tests/lib/rules/no-array-prototype-filter.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-find.ts
+++ b/tests/lib/rules/no-array-prototype-find.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-findindex.ts
+++ b/tests/lib/rules/no-array-prototype-findindex.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-findlast-findlastindex.ts
+++ b/tests/lib/rules/no-array-prototype-findlast-findlastindex.ts
@@ -64,7 +64,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-flat.ts
+++ b/tests/lib/rules/no-array-prototype-flat.ts
@@ -51,7 +51,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-foreach.ts
+++ b/tests/lib/rules/no-array-prototype-foreach.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-includes.ts
+++ b/tests/lib/rules/no-array-prototype-includes.ts
@@ -48,7 +48,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-indexof.ts
+++ b/tests/lib/rules/no-array-prototype-indexof.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-keys.ts
+++ b/tests/lib/rules/no-array-prototype-keys.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-lastindexof.ts
+++ b/tests/lib/rules/no-array-prototype-lastindexof.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-map.ts
+++ b/tests/lib/rules/no-array-prototype-map.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-reduce.ts
+++ b/tests/lib/rules/no-array-prototype-reduce.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-reduceright.ts
+++ b/tests/lib/rules/no-array-prototype-reduceright.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-some.ts
+++ b/tests/lib/rules/no-array-prototype-some.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-toreversed.ts
+++ b/tests/lib/rules/no-array-prototype-toreversed.ts
@@ -51,7 +51,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-tosorted.ts
+++ b/tests/lib/rules/no-array-prototype-tosorted.ts
@@ -45,7 +45,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-tospliced.ts
+++ b/tests/lib/rules/no-array-prototype-tospliced.ts
@@ -45,7 +45,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-values.ts
+++ b/tests/lib/rules/no-array-prototype-values.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-prototype-with.ts
+++ b/tests/lib/rules/no-array-prototype-with.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-array-string-prototype-at.ts
+++ b/tests/lib/rules/no-array-string-prototype-at.ts
@@ -54,7 +54,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-dataview-prototype-getfloat16-setfloat16.ts
+++ b/tests/lib/rules/no-dataview-prototype-getfloat16-setfloat16.ts
@@ -63,7 +63,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-date-prototype-getyear-setyear.ts
+++ b/tests/lib/rules/no-date-prototype-getyear-setyear.ts
@@ -59,7 +59,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-date-prototype-togmtstring.ts
+++ b/tests/lib/rules/no-date-prototype-togmtstring.ts
@@ -77,7 +77,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-date-prototype-totemporalinstant.ts
+++ b/tests/lib/rules/no-date-prototype-totemporalinstant.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-function-prototype-bind.ts
+++ b/tests/lib/rules/no-function-prototype-bind.ts
@@ -85,7 +85,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-datetimeformat-prototype-formatrange.ts
+++ b/tests/lib/rules/no-intl-datetimeformat-prototype-formatrange.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-datetimeformat-prototype-formattoparts.ts
+++ b/tests/lib/rules/no-intl-datetimeformat-prototype-formattoparts.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-firstdayofweek.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-firstdayofweek.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-getcalendars.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-getcalendars.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-getcollations.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-getcollations.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-gethourcycles.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-gethourcycles.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-getnumberingsystems.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-getnumberingsystems.ts
@@ -50,7 +50,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-gettextinfo.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-gettextinfo.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-gettimezones.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-gettimezones.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-locale-prototype-getweekinfo.ts
+++ b/tests/lib/rules/no-intl-locale-prototype-getweekinfo.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-numberformat-prototype-formatrange.ts
+++ b/tests/lib/rules/no-intl-numberformat-prototype-formatrange.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-numberformat-prototype-formatrangetoparts.ts
+++ b/tests/lib/rules/no-intl-numberformat-prototype-formatrangetoparts.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-numberformat-prototype-formattoparts.ts
+++ b/tests/lib/rules/no-intl-numberformat-prototype-formattoparts.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-intl-pluralrules-prototype-selectrange.ts
+++ b/tests/lib/rules/no-intl-pluralrules-prototype-selectrange.ts
@@ -42,7 +42,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-drop.ts
+++ b/tests/lib/rules/no-iterator-prototype-drop.ts
@@ -148,7 +148,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-every.ts
+++ b/tests/lib/rules/no-iterator-prototype-every.ts
@@ -145,7 +145,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-filter.ts
+++ b/tests/lib/rules/no-iterator-prototype-filter.ts
@@ -145,7 +145,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-find.ts
+++ b/tests/lib/rules/no-iterator-prototype-find.ts
@@ -145,7 +145,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-flatmap.ts
+++ b/tests/lib/rules/no-iterator-prototype-flatmap.ts
@@ -167,7 +167,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-foreach.ts
+++ b/tests/lib/rules/no-iterator-prototype-foreach.ts
@@ -167,7 +167,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-map.ts
+++ b/tests/lib/rules/no-iterator-prototype-map.ts
@@ -145,7 +145,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-reduce.ts
+++ b/tests/lib/rules/no-iterator-prototype-reduce.ts
@@ -145,7 +145,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-some.ts
+++ b/tests/lib/rules/no-iterator-prototype-some.ts
@@ -145,7 +145,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-take.ts
+++ b/tests/lib/rules/no-iterator-prototype-take.ts
@@ -148,7 +148,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-iterator-prototype-toarray.ts
+++ b/tests/lib/rules/no-iterator-prototype-toarray.ts
@@ -167,7 +167,7 @@ new RuleTester({
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-map-prototype-getorinsert.ts
+++ b/tests/lib/rules/no-map-prototype-getorinsert.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-map-prototype-getorinsertcomputed.ts
+++ b/tests/lib/rules/no-map-prototype-getorinsertcomputed.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-array-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-array-prototype-properties.ts
@@ -94,7 +94,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-arraybuffer-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-arraybuffer-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-asyncdisposablestack-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-asyncdisposablestack-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-bigint-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-bigint-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-boolean-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-boolean-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-dataview-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-dataview-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-date-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-date-prototype-properties.ts
@@ -50,7 +50,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-disposablestack-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-disposablestack-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-finalizationregistry-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-finalizationregistry-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-collator-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-collator-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-datetimeformat-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-datetimeformat-prototype-properties.ts
@@ -77,7 +77,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-displaynames-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-displaynames-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-durationformat-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-durationformat-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-listformat-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-listformat-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-locale-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-locale-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-numberformat-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-numberformat-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-pluralrules-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-pluralrules-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-relativetimeformat-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-relativetimeformat-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-intl-segmenter-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-intl-segmenter-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-iterator-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-iterator-prototype-properties.ts
@@ -64,7 +64,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-map-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-map-prototype-properties.ts
@@ -46,7 +46,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-number-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-number-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-promise-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-promise-prototype-properties.ts
@@ -65,7 +65,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-regexp-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-regexp-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-set-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-set-prototype-properties.ts
@@ -46,7 +46,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-sharedarraybuffer-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-sharedarraybuffer-prototype-properties.ts
@@ -61,7 +61,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-string-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-string-prototype-properties.ts
@@ -270,7 +270,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-symbol-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-symbol-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-duration-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-duration-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-instant-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-instant-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-plaindate-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-plaindate-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-plaindatetime-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-plaindatetime-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-plainmonthday-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-plainmonthday-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-plaintime-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-plaintime-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-plainyearmonth-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-plainyearmonth-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-temporal-zoneddatetime-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-temporal-zoneddatetime-prototype-properties.ts
@@ -49,7 +49,7 @@ new RuleTester().run(ruleId, rule, {
 // -----------------------------------------------------------------------------
 // TypeScript
 // -----------------------------------------------------------------------------
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-typed-array-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-typed-array-prototype-properties.ts
@@ -76,7 +76,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-weakmap-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-weakmap-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-weakref-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-weakref-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-nonstandard-weakset-prototype-properties.ts
+++ b/tests/lib/rules/no-nonstandard-weakset-prototype-properties.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-promise-prototype-finally.ts
+++ b/tests/lib/rules/no-promise-prototype-finally.ts
@@ -41,7 +41,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-regexp-prototype-compile.ts
+++ b/tests/lib/rules/no-regexp-prototype-compile.ts
@@ -59,7 +59,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-regexp-prototype-flags.ts
+++ b/tests/lib/rules/no-regexp-prototype-flags.ts
@@ -71,7 +71,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-resizable-and-growable-arraybuffers.ts
+++ b/tests/lib/rules/no-resizable-and-growable-arraybuffers.ts
@@ -146,7 +146,7 @@ new RuleTester(testerOptions).run(ruleId, rule, {
 })
 
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-difference.ts
+++ b/tests/lib/rules/no-set-prototype-difference.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-intersection.ts
+++ b/tests/lib/rules/no-set-prototype-intersection.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-isdisjointfrom.ts
+++ b/tests/lib/rules/no-set-prototype-isdisjointfrom.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-issubsetof.ts
+++ b/tests/lib/rules/no-set-prototype-issubsetof.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-issupersetof.ts
+++ b/tests/lib/rules/no-set-prototype-issupersetof.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-symmetricdifference.ts
+++ b/tests/lib/rules/no-set-prototype-symmetricdifference.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-set-prototype-union.ts
+++ b/tests/lib/rules/no-set-prototype-union.ts
@@ -40,7 +40,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-create-html-methods.ts
+++ b/tests/lib/rules/no-string-create-html-methods.ts
@@ -119,7 +119,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-at.ts
+++ b/tests/lib/rules/no-string-prototype-at.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-codepointat.ts
+++ b/tests/lib/rules/no-string-prototype-codepointat.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-endswith.ts
+++ b/tests/lib/rules/no-string-prototype-endswith.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-includes.ts
+++ b/tests/lib/rules/no-string-prototype-includes.ts
@@ -48,7 +48,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-iswellformed-towellformed.ts
+++ b/tests/lib/rules/no-string-prototype-iswellformed-towellformed.ts
@@ -72,7 +72,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-iswellformed.ts
+++ b/tests/lib/rules/no-string-prototype-iswellformed.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-matchall.ts
+++ b/tests/lib/rules/no-string-prototype-matchall.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-normalize.ts
+++ b/tests/lib/rules/no-string-prototype-normalize.ts
@@ -50,7 +50,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-padstart-padend.ts
+++ b/tests/lib/rules/no-string-prototype-padstart-padend.ts
@@ -56,7 +56,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-repeat.ts
+++ b/tests/lib/rules/no-string-prototype-repeat.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-replaceall.ts
+++ b/tests/lib/rules/no-string-prototype-replaceall.ts
@@ -526,7 +526,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-startswith.ts
+++ b/tests/lib/rules/no-string-prototype-startswith.ts
@@ -50,7 +50,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-substr.ts
+++ b/tests/lib/rules/no-string-prototype-substr.ts
@@ -45,7 +45,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-towellformed.ts
+++ b/tests/lib/rules/no-string-prototype-towellformed.ts
@@ -43,7 +43,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-trim.ts
+++ b/tests/lib/rules/no-string-prototype-trim.ts
@@ -44,7 +44,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-trimleft-trimright.ts
+++ b/tests/lib/rules/no-string-prototype-trimleft-trimright.ts
@@ -97,7 +97,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-string-prototype-trimstart-trimend.ts
+++ b/tests/lib/rules/no-string-prototype-trimstart-trimend.ts
@@ -69,7 +69,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-symbol-prototype-description.ts
+++ b/tests/lib/rules/no-symbol-prototype-description.ts
@@ -87,7 +87,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-uint8array-prototype-setfrombase64.ts
+++ b/tests/lib/rules/no-uint8array-prototype-setfrombase64.ts
@@ -70,7 +70,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-uint8array-prototype-setfromhex.ts
+++ b/tests/lib/rules/no-uint8array-prototype-setfromhex.ts
@@ -70,7 +70,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-uint8array-prototype-tobase64.ts
+++ b/tests/lib/rules/no-uint8array-prototype-tobase64.ts
@@ -70,7 +70,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-uint8array-prototype-tohex.ts
+++ b/tests/lib/rules/no-uint8array-prototype-tohex.ts
@@ -70,7 +70,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-weakmap-prototype-getorinsert.ts
+++ b/tests/lib/rules/no-weakmap-prototype-getorinsert.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/rules/no-weakmap-prototype-getorinsertcomputed.ts
+++ b/tests/lib/rules/no-weakmap-prototype-getorinsertcomputed.ts
@@ -47,7 +47,7 @@ new RuleTester().run(ruleId, rule, {
 // TypeScript
 // -----------------------------------------------------------------------------
 import * as parser from "@typescript-eslint/parser"
-const tsconfigRootDir = path.resolve(__dirname, "../../fixtures")
+const tsconfigRootDir = path.resolve(import.meta.dirname, "../../fixtures")
 const project = "tsconfig.json"
 const filename = path.join(tsconfigRootDir, "test.ts")
 

--- a/tests/lib/util/define-regexp-handler.ts
+++ b/tests/lib/util/define-regexp-handler.ts
@@ -7,7 +7,10 @@ import { ESLint } from "eslint"
 // Tests
 // -----------------------------------------------------------------------------
 
-const TEST_CWD = path.join(__dirname, "../fixtures/integrations/eslint-plugin")
+const TEST_CWD = path.join(
+    import.meta.dirname,
+    "../fixtures/integrations/eslint-plugin",
+)
 
 describe("define-regexp-handler", () => {
     it("should lint with errors", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
