### PR TITLE
Fix Release and GHPages workflow failures

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -36,8 +36,8 @@ jobs:
         id: changesets
         uses: changesets/action@v2.0.0
         with:
-          version: npm run changeset:version
-          publish: npm run changeset:publish
+          version-script: npm run changeset:version
+          publish-script: npm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitepress"
 import path from "node:path"
 import eslint4b from "vite-plugin-eslint4b"
 import { categories } from "../../scripts/rules"
-import monacoEditorPackageJson from "monaco-editor/package.json" with { type: "json" }
+import monacoEditorPackageJson from "../../node_modules/monaco-editor/package.json" with { type: "json" }
 
 export default defineConfig({
     title: "eslint-plugin-es-x",


### PR DESCRIPTION
`changesets/action@v2` renamed the `version` and `publish` inputs; continuing to use those names makes the Release job fail before it can inspect changesets. This updates the workflow to `version-script` and `publish-script`.

`monaco-editor@0.56` also changed its wildcard exports, causing `monaco-editor/package.json` to resolve to a nonexistent module. The VitePress config now reads the direct dependency metadata by relative path so docs can build and Pages can deploy again.